### PR TITLE
chore(release): 2.1.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "@stephendolan/helpscout-cli",
       "dependencies": {
         "@napi-rs/keyring": "^1.2.0",
-        "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "conf": "^12.0.0",
         "dayjs": "^1.11.19",
@@ -232,8 +231,6 @@
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
-
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/helpscout-cli",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A command-line interface for Help Scout",
   "type": "module",
   "main": "./dist/cli.js",
@@ -45,7 +45,6 @@
   ],
   "dependencies": {
     "@napi-rs/keyring": "^1.2.0",
-    "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "conf": "^12.0.0",
     "dayjs": "^1.11.19",


### PR DESCRIPTION
## Summary

Patch release that removes the unused chalk dependency, reducing bundle size and dependency footprint.

## Problem

The chalk package was listed as a dependency but was never imported or used in the codebase, adding unnecessary weight to the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)