### PR TITLE
chore(release): 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/helpscout-cli",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A command-line interface for Help Scout",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -219,6 +219,7 @@ export class HelpScoutClient {
       tag?: string;
       assignedTo?: string;
       query?: string;
+      embed?: string;
     } = {}
   ): Promise<Conversation[]> {
     const allConversations: Conversation[] = [];

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -11,7 +11,7 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function htmlToPlainText(html: string): string {
+export function htmlToPlainText(html: string): string {
   const text = convert(html, {
     wordwrap: false,
     preserveNewlines: false,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,6 +66,9 @@ export interface Conversation {
     email?: string;
   };
   customFields?: CustomField[];
+  _embedded?: {
+    threads?: Thread[];
+  };
 }
 
 export interface Thread {


### PR DESCRIPTION
## Summary

Enhanced conversation summary output with structured participant information. The summary now includes detailed customer and user objects with names, emails, message counts, and first messages (truncated to 300 chars). Replaced the simple preview field with richer participant data and improved thread filtering logic.

## Problem

The conversation summary output lacked detailed participant information, making it difficult for LLMs and developers to quickly understand who was involved in conversations and what their initial messages were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)