### PR TITLE
chore(release): v2.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/helpscout-cli",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "A command-line interface for Help Scout",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,12 +7,6 @@ const REFRESH_TOKEN_ACCOUNT = 'refresh-token';
 const APP_ID_ACCOUNT = 'app-id';
 const APP_SECRET_ACCOUNT = 'app-secret';
 
-const KEYRING_UNAVAILABLE_ERROR =
-  'Keychain storage unavailable. Cannot store credentials securely.\n' +
-  'On Linux, install libsecret: sudo apt-get install libsecret-1-dev\n' +
-  'Then reinstall: bun install -g @stephendolan/helpscout-cli\n' +
-  'Alternatively, use HELPSCOUT_APP_ID and HELPSCOUT_APP_SECRET environment variables.';
-
 const keyringCache = new Map<string, Entry | null>();
 
 function getKeyring(account: string): Entry | null {
@@ -41,12 +35,13 @@ async function getPassword(account: string): Promise<string | null> {
   return null;
 }
 
-async function setPassword(account: string, value: string): Promise<void> {
+async function setPassword(account: string, value: string): Promise<boolean> {
   const entry = getKeyring(account);
   if (!entry) {
-    throw new Error(KEYRING_UNAVAILABLE_ERROR);
+    return false;
   }
   entry.setPassword(value);
+  return true;
 }
 
 async function deletePassword(account: string): Promise<boolean> {
@@ -62,7 +57,7 @@ export class AuthManager {
     return getPassword(ACCESS_TOKEN_ACCOUNT);
   }
 
-  async setAccessToken(token: string): Promise<void> {
+  async setAccessToken(token: string): Promise<boolean> {
     return setPassword(ACCESS_TOKEN_ACCOUNT, token);
   }
 
@@ -70,7 +65,7 @@ export class AuthManager {
     return getPassword(REFRESH_TOKEN_ACCOUNT);
   }
 
-  async setRefreshToken(token: string): Promise<void> {
+  async setRefreshToken(token: string): Promise<boolean> {
     return setPassword(REFRESH_TOKEN_ACCOUNT, token);
   }
 
@@ -79,7 +74,7 @@ export class AuthManager {
     return keychainValue || process.env.HELPSCOUT_APP_ID || null;
   }
 
-  async setAppId(appId: string): Promise<void> {
+  async setAppId(appId: string): Promise<boolean> {
     return setPassword(APP_ID_ACCOUNT, appId);
   }
 
@@ -88,7 +83,7 @@ export class AuthManager {
     return keychainValue || process.env.HELPSCOUT_APP_SECRET || null;
   }
 
-  async setAppSecret(appSecret: string): Promise<void> {
+  async setAppSecret(appSecret: string): Promise<boolean> {
     return setPassword(APP_SECRET_ACCOUNT, appSecret);
   }
 


### PR DESCRIPTION
## Summary

- Add graceful keychain handling for headless environments (CI/CD, Docker, SSH sessions)
- Return `null` instead of throwing errors when keychain access fails
- Improves reliability when running in environments without keychain support

## Test plan

- [ ] Verify authentication works normally in environments with keychain access
- [ ] Verify CLI gracefully falls back to environment variables in headless environments
- [ ] Run `bun test` to ensure all tests pass
- [ ] Run `bun run typecheck` to verify types

---

🤖 Generated with [Claude Code](https://claude.ai/code)