### PR TITLE
Add `--status` flag to `conversations note` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ helpscout conversations threads 456 --type customer  # Filter by type
 helpscout conversations threads 456 --html          # HTML output
 helpscout conversations threads 456 --include-notes
 helpscout conversations reply 456 --text "Thanks for reaching out!"
+helpscout conversations reply 456 --text "Issue resolved" --status closed
 helpscout conversations note 456 --text "Internal note"
+helpscout conversations note 456 --text "Escalating to engineering" --status pending
 helpscout conversations add-tag 456 urgent
 helpscout conversations remove-tag 456 urgent
 helpscout conversations delete 456

--- a/src/commands/conversations.ts
+++ b/src/commands/conversations.ts
@@ -320,6 +320,7 @@ export function createConversationsCommand(): Command {
     .argument('<id>', 'Conversation ID')
     .requiredOption('--text <text>', 'Note text')
     .option('--user <id>', 'User ID adding the note')
+    .option('--status <status>', 'Set conversation status after note (active, closed, pending)')
     .action(
       withErrorHandling(
         async (
@@ -327,11 +328,13 @@ export function createConversationsCommand(): Command {
           options: {
             text: string;
             user?: string;
+            status?: string;
           }
         ) => {
           await client.createNote(parseIdArg(id, 'conversation'), {
             text: options.text,
             user: options.user ? parseIdArg(options.user, 'user') : undefined,
+            status: options.status,
           });
           outputJson({ message: 'Note added' });
         }

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -293,6 +293,7 @@ export class HelpScoutClient {
     data: {
       text: string;
       user?: number;
+      status?: string;
     }
   ) {
     await this.request<void>('POST', `/conversations/${conversationId}/notes`, { body: data });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -183,9 +183,13 @@ server.tool(
   {
     conversationId: z.number().describe('Conversation ID'),
     text: z.string().describe('Note text content'),
+    status: z
+      .enum(['active', 'closed', 'pending'])
+      .optional()
+      .describe('Set conversation status after note'),
   },
-  async ({ conversationId, text }) => {
-    await client.createNote(conversationId, { text });
+  async ({ conversationId, text, status }) => {
+    await client.createNote(conversationId, { text, status });
     return jsonResponse({ success: true });
   }
 );


### PR DESCRIPTION
## Summary

The `note` command was missing the `--status` option that the `reply` command already has. The Help Scout API supports setting status when creating notes, so this adds parity with the `reply` command.

## Changes
- Add `status` parameter to `createNote()` in `api-client.ts`
- Add `--status` option to `note` command in `conversations.ts`
- Add `status` parameter to `create_note` MCP tool in `server.ts`
- Update README with `--status` examples for both `reply` and `note`

## Usage

```bash
# Close conversation with resolution note
helpscout conversations note 12345 --text "Issue resolved" --status closed

# Mark as pending while waiting
helpscout conversations note 12345 --text "Waiting for response" --status pending

## Testing Performed

- `bun run build` passes
- `bun run typecheck` passes
- `bun run lint` passes
- Tested against live Help Scout data

Closes upstream issue #18