### PR TITLE
chore(release): v2.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/helpscout-cli",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "A command-line interface for Help Scout",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -57,8 +57,8 @@ server.tool(
   {
     status: z
       .enum(['active', 'pending', 'closed', 'spam', 'all'])
-      .optional()
-      .describe('Conversation status filter'),
+      .default('all')
+      .describe('Conversation status filter (defaults to "all" to include resolved tickets)'),
     mailbox: z.string().optional().describe('Mailbox ID to filter by'),
     tag: z.string().optional().describe('Tag to filter by'),
     assignedTo: z.string().optional().describe('User ID assigned to'),
@@ -97,7 +97,7 @@ server.tool(
   'Search all conversations matching a query (fetches all pages)',
   {
     query: z.string().optional().describe('Search query (e.g., "email:domain.com", "subject:billing")'),
-    status: z.enum(['active', 'pending', 'closed', 'spam', 'all']).optional().describe('Status filter'),
+    status: z.enum(['active', 'pending', 'closed', 'spam', 'all']).default('all').describe('Status filter (defaults to "all" to include resolved tickets)'),
     createdSince: z.string().optional().describe('Show conversations created after this date (ISO 8601)'),
     createdBefore: z.string().optional().describe('Show conversations created before this date'),
     modifiedSince: z.string().optional().describe('Show conversations modified after this date'),


### PR DESCRIPTION
## Summary

- Default `search_conversations` and `list_conversations` MCP tools to `status: "all"` instead of HelpScout's API default of `active` only
- Fixes AI agents silently missing resolved/closed tickets when searching support history

## Why

Discovered via Sherlock investigation: HelpScout's API defaults to active-only, making all resolved tickets invisible. An AI searching `email:user@company.com` would return 0 results even when 25+ closed tickets exist for that customer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)