### PR TITLE
chore(release): v2.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/helpscout-cli",
-  "version": "2.9.3",
+  "version": "2.10.0",
   "description": "A command-line interface for Help Scout",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/commands/conversations.ts
+++ b/src/commands/conversations.ts
@@ -285,13 +285,11 @@ export function createConversationsCommand(): Command {
     );
 
   cmd
-    .command('reply')
-    .description('Reply to a conversation')
+    .command('draft-reply')
+    .description('Create a draft reply on an existing conversation (never sends — review and send from the Help Scout UI)')
     .argument('<id>', 'Conversation ID')
     .requiredOption('--text <text>', 'Reply text')
-    .option('--user <id>', 'User ID sending the reply')
-    .option('--draft', 'Save as draft')
-    .option('--status <status>', 'Set conversation status after reply (active, closed, pending)')
+    .option('--user <id>', 'User ID authoring the draft')
     .action(
       withErrorHandling(
         async (
@@ -299,17 +297,51 @@ export function createConversationsCommand(): Command {
           options: {
             text: string;
             user?: string;
-            draft?: boolean;
-            status?: string;
           }
         ) => {
-          await client.createReply(parseIdArg(id, 'conversation'), {
+          await client.createDraftReply(parseIdArg(id, 'conversation'), {
             text: options.text,
             user: options.user ? parseIdArg(options.user, 'user') : undefined,
-            draft: options.draft,
-            status: options.status,
           });
-          outputJson({ message: 'Reply sent' });
+          outputJson({ message: 'Draft reply created' });
+        }
+      )
+    );
+
+  cmd
+    .command('draft-conversation')
+    .description('Create a new outbound draft conversation (never sends — review and send from the Help Scout UI)')
+    .requiredOption('--mailbox <id>', 'Mailbox ID to create the conversation in')
+    .requiredOption('--customer-email <email>', 'Recipient customer email address')
+    .requiredOption('--subject <subject>', 'Conversation subject')
+    .requiredOption('--text <text>', 'Draft message body')
+    .option('--user <id>', 'User ID authoring the draft')
+    .option('--type <type>', 'Conversation type: email, chat, or phone (default email)')
+    .option('--status <status>', 'Conversation status: active, pending, or closed (default active)')
+    .option('--tag <tag...>', 'Tag to apply (repeatable)')
+    .action(
+      withErrorHandling(
+        async (options: {
+          mailbox: string;
+          customerEmail: string;
+          subject: string;
+          text: string;
+          user?: string;
+          type?: 'email' | 'chat' | 'phone';
+          status?: 'active' | 'pending' | 'closed';
+          tag?: string[];
+        }) => {
+          const result = await client.createDraftConversation({
+            mailboxId: parseIdArg(options.mailbox, 'mailbox'),
+            customerEmail: options.customerEmail,
+            subject: options.subject,
+            text: options.text,
+            user: options.user ? parseIdArg(options.user, 'user') : undefined,
+            type: options.type,
+            status: options.status,
+            tags: options.tag,
+          });
+          outputJson({ message: 'Draft conversation created', conversationId: result.id });
         }
       )
     );

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -115,7 +115,7 @@ export class HelpScoutClient {
     return this.refreshAccessToken();
   }
 
-  private async request<T>(
+  private async rawRequest(
     method: string,
     path: string,
     options: {
@@ -124,7 +124,7 @@ export class HelpScoutClient {
       retry?: boolean;
       rateLimitRetry?: boolean;
     } = {}
-  ): Promise<T> {
+  ): Promise<Response> {
     const { params, body, retry = true, rateLimitRetry = true } = options;
 
     const url = new URL(`${API_BASE}${path}`);
@@ -159,7 +159,7 @@ export class HelpScoutClient {
     if (response.status === 401 && retry) {
       this.accessToken = null;
       await this.refreshAccessToken();
-      return this.request(method, path, { ...options, retry: false });
+      return this.rawRequest(method, path, { ...options, retry: false });
     }
 
     if (response.status === 429 && rateLimitRetry) {
@@ -169,11 +169,7 @@ export class HelpScoutClient {
         JSON.stringify({ warning: `Rate limited. Waiting ${waitSeconds}s before retry...` })
       );
       await new Promise((resolve) => setTimeout(resolve, waitSeconds * 1000));
-      return this.request(method, path, { ...options, rateLimitRetry: false });
-    }
-
-    if (response.status === 204) {
-      return {} as T;
+      return this.rawRequest(method, path, { ...options, rateLimitRetry: false });
     }
 
     if (!response.ok) {
@@ -181,6 +177,23 @@ export class HelpScoutClient {
       throw new HelpScoutApiError('API request failed', error, response.status);
     }
 
+    return response;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    options: {
+      params?: Record<string, string | number | boolean | undefined>;
+      body?: unknown;
+      retry?: boolean;
+      rateLimitRetry?: boolean;
+    } = {}
+  ): Promise<T> {
+    const response = await this.rawRequest(method, path, options);
+    if (response.status === 204) {
+      return {} as T;
+    }
     return response.json() as Promise<T>;
   }
 
@@ -280,16 +293,58 @@ export class HelpScoutClient {
     });
   }
 
-  async createReply(
+  async createDraftReply(
     conversationId: number,
     data: {
       text: string;
       user?: number;
-      draft?: boolean;
-      status?: string;
     }
   ) {
-    await this.request<void>('POST', `/conversations/${conversationId}/reply`, { body: data });
+    await this.request<void>('POST', `/conversations/${conversationId}/reply`, {
+      body: { ...data, draft: true },
+    });
+  }
+
+  async createDraftConversation(data: {
+    subject: string;
+    mailboxId: number;
+    customerEmail: string;
+    text: string;
+    type?: 'email' | 'chat' | 'phone';
+    status?: 'active' | 'pending' | 'closed';
+    user?: number;
+    tags?: string[];
+  }): Promise<{ id: number }> {
+    const { subject, mailboxId, customerEmail, text, type = 'email', status = 'active', user, tags } = data;
+    const response = await this.rawRequest('POST', '/conversations', {
+      body: {
+        subject,
+        mailboxId,
+        type,
+        status,
+        customer: { email: customerEmail },
+        threads: [
+          {
+            type: 'reply',
+            customer: { email: customerEmail },
+            text,
+            draft: true,
+            ...(user !== undefined && { user }),
+          },
+        ],
+        ...(tags && { tags }),
+      },
+    });
+
+    const location = response.headers.get('Location') || '';
+    const match = location.match(/\/conversations\/(\d+)/);
+    if (!match) {
+      throw new HelpScoutCliError(
+        'Draft conversation created but could not parse ID from Location header',
+        0,
+      );
+    }
+    return { id: parseInt(match[1], 10) };
   }
 
   async createNote(

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -89,8 +89,9 @@ const toolRegistry = [
   { name: 'get_customer', description: 'Get detailed information about a specific customer' },
   { name: 'list_tags', description: 'List all tags in the Help Scout account' },
   { name: 'list_workflows', description: 'List workflows with optional filtering' },
-  { name: 'create_note', description: 'Add a private note to a conversation' },
-  { name: 'create_draft', description: 'Create a draft reply on a conversation (saves without sending)' },
+  { name: 'create_note', description: 'Add a private note to an existing conversation' },
+  { name: 'create_draft_reply', description: 'Create a draft reply on an existing conversation (saves without sending). Use when responding to a ticket.' },
+  { name: 'create_draft_conversation', description: 'Create a brand-new outbound draft conversation for proactive customer outreach (saves without sending). Use when starting a new ticket from scratch.' },
   { name: 'add_tag', description: 'Add a tag to a conversation' },
   { name: 'check_auth', description: 'Check if Help Scout authentication is configured' },
 ];
@@ -288,15 +289,41 @@ server.tool(
 );
 
 server.tool(
-  'create_draft',
-  'Create a draft reply on a conversation (saves without sending)',
+  'create_draft_reply',
+  'Create a draft reply on an existing conversation (saves without sending). Use this when responding to an existing ticket — the draft is reviewed and sent from the Help Scout UI. For starting a brand-new outbound conversation, use create_draft_conversation instead.',
   {
-    conversationId: z.number().describe('Conversation ID'),
-    text: z.string().describe('Draft reply text content'),
+    conversationId: z.number().describe('Existing conversation ID to attach the draft reply to'),
+    text: z.string().describe('Draft reply text content (HTML or plain text)'),
   },
   async ({ conversationId, text }) => {
-    await client.createReply(conversationId, { text, draft: true });
+    await client.createDraftReply(conversationId, { text });
     return jsonResponse({ success: true });
+  }
+);
+
+server.tool(
+  'create_draft_conversation',
+  'Create a brand-new outbound draft conversation for proactive customer outreach (saves without sending). Use this when starting a new ticket from scratch — the draft is reviewed and sent from the Help Scout UI. For replying to an existing conversation, use create_draft_reply instead.',
+  {
+    mailboxId: z.number().describe('Mailbox ID to create the conversation in'),
+    customerEmail: z.string().email().describe('Recipient customer email address'),
+    subject: z.string().describe('Conversation subject line'),
+    text: z.string().describe('Draft message body (HTML or plain text)'),
+    type: z.enum(['email', 'chat', 'phone']).optional().describe('Conversation medium (default "email")'),
+    status: z.enum(['active', 'pending', 'closed']).optional().describe('Conversation status (default "active")'),
+    tags: z.array(z.string()).optional().describe('Tags to apply to the conversation'),
+  },
+  async ({ mailboxId, customerEmail, subject, text, type, status, tags }) => {
+    const result = await client.createDraftConversation({
+      mailboxId,
+      customerEmail,
+      subject,
+      text,
+      type,
+      status,
+      tags,
+    });
+    return jsonResponse({ success: true, conversationId: result.id });
   }
 );
 


### PR DESCRIPTION
## Summary

- Add `create_draft_conversation` MCP tool + `helpscout conversations draft-conversation` CLI command for proactive outbound draft tickets.
- Rename `create_draft` → `create_draft_reply` (MCP) and `conversations reply` → `conversations draft-reply` (CLI) for parallel naming and clearer intent.
- Lock down all write paths to draft-only. `createDraftReply` forces `draft: true` internally; the client no longer exposes a live-send path. Prevents agents from accidentally shipping outbound messages via the MCP server.

## Test plan

- [x] Typecheck passes
- [x] Lint passes
- [x] 27 existing tests pass
- [ ] Manual: `helpscout conversations draft-reply <id> --text "test"` creates a draft on an existing conversation
- [ ] Manual: `helpscout conversations draft-conversation --mailbox <id> --customer-email ... --subject ... --text ...` creates a new draft conversation
- [ ] Manual: MCP `create_draft_reply` and `create_draft_conversation` tools work via agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)