### PR TITLE
chore(release): v2.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/helpscout-cli",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "A command-line interface for Help Scout",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -238,8 +238,10 @@ const sourceSchema = z.object({
 
 const tagSchema = z.object({
   id: z.number().optional(),
-  name: z.string(),
-  slug: z.string(),
+  name: z.string().optional(),
+  slug: z.string().optional(),
+  tag: z.string().optional(),
+  color: z.string().optional(),
   createdAt: z.string().optional(),
   updatedAt: z.string().optional(),
   ticketCount: z.number().optional(),
@@ -483,7 +485,8 @@ function summarizeConversations(conversations: Conversation[]): ConversationSumm
   for (const conv of conversations) {
     byStatus[conv.status] = (byStatus[conv.status] || 0) + 1;
     for (const tag of conv.tags || []) {
-      byTag[tag.name] = (byTag[tag.name] || 0) + 1;
+      const label = tag.name ?? (tag as { tag?: string }).tag ?? 'unknown';
+      byTag[label] = (byTag[label] || 0) + 1;
     }
   }
 


### PR DESCRIPTION
## Summary
- Relax MCP tag Zod schema so conversations containing tags no longer fail validation (embedded tags use `{id, tag, color}` rather than `{name, slug}`).
- Patch release: 2.12.0 → 2.12.1.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run build`
- [ ] After merge + tag, confirm GitHub Actions publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)