### PR TITLE
feat(conversations): add --status flag to note command

### DIFF
--- a/src/commands/conversations.ts
+++ b/src/commands/conversations.ts
@@ -366,6 +366,7 @@ export function createConversationsCommand(): Command {
     .argument('<id>', 'Conversation ID')
     .requiredOption('--text <text>', 'Note text')
     .option('--user <id>', 'User ID adding the note')
+    .option('--status <status>', 'Set conversation status after adding the note (active, open, pending, closed, spam)')
     .action(
       withErrorHandling(
         async (
@@ -373,13 +374,21 @@ export function createConversationsCommand(): Command {
           options: {
             text: string;
             user?: string;
+            status?: string;
           }
         ) => {
+          const status = options.status
+            ? normalizeConversationStatus(options.status)
+            : undefined;
           await client.createNote(parseIdArg(id, 'conversation'), {
             text: options.text,
             user: options.user ? parseIdArg(options.user, 'user') : undefined,
+            status,
           });
-          outputJson({ message: 'Note added' });
+          outputJson({
+            message: 'Note added',
+            ...(status && { status }),
+          });
         }
       )
     );

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -358,6 +358,7 @@ export class HelpScoutClient {
     data: {
       text: string;
       user?: number;
+      status?: ConversationStatus;
     }
   ) {
     await this.request<void>('POST', `/conversations/${conversationId}/notes`, { body: data });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -442,6 +442,10 @@ const conversationStatusOutputSchema = conversationActionOutputSchema.extend({
   status: z.enum(['active', 'pending', 'closed', 'spam']),
 });
 
+const noteOutputSchema = conversationActionOutputSchema.extend({
+  status: z.enum(['active', 'pending', 'closed', 'spam']).optional(),
+});
+
 const taggedConversationOutputSchema = conversationActionOutputSchema.extend({
   tag: z.string(),
 });
@@ -879,13 +883,22 @@ server.registerTool(
     inputSchema: {
       conversationId: z.number().describe('Conversation ID'),
       text: z.string().describe('Note text content'),
+      status: z
+        .string()
+        .optional()
+        .describe('Optionally set the conversation status after adding the note (active, open, pending, closed, spam)'),
     },
-    outputSchema: conversationActionOutputSchema,
+    outputSchema: noteOutputSchema,
     annotations: MUTATING_REMOTE_ANNOTATIONS,
   },
-  async ({ conversationId, text }) => {
-    await client.createNote(conversationId, { text });
-    return structuredJsonResult({ success: true, conversationId });
+  async ({ conversationId, text, status }) => {
+    const normalizedStatus = status ? normalizeConversationStatus(status) : undefined;
+    await client.createNote(conversationId, { text, status: normalizedStatus });
+    return structuredJsonResult({
+      success: true,
+      conversationId,
+      ...(normalizedStatus && { status: normalizedStatus }),
+    });
   },
 );
 


### PR DESCRIPTION
## Problem

`helpscout conversations note` could add a note but not change the conversation's status in the same call. Common support workflows (document a resolution and close, or leave a note and mark pending) required a second `conversations status` invocation. The Help Scout notes endpoint already accepts an optional `status` field.

## Change

- Add `--status <status>` to the `conversations note` command. Values are validated and normalized via the existing `normalizeConversationStatus` helper, so it shares the same validation, error message, and `open` -> `active` alias as the `status` and `draft-conversation` commands.
- Thread the optional `status` through `HelpScoutClient.createNote`. Because the request body is `JSON.stringify`-ed, an unset status is dropped from the payload (same pattern already used for the optional `user` field).
- Mirror the option on the MCP `create_note` tool for parity across the CLI's surfaces. Output reflects the applied status when set.

The status is echoed back in the success output only when provided:

```json
{ "message": "Note added", "status": "closed" }
```

## Notes

The issue referenced a `conversations reply --status` command as the pattern to mirror; the actual codebase has `draft-reply` (no status) and a separate `status` command, so this follows the established `normalizeConversationStatus` pattern instead. Scope is limited to `--status`; the other optional API params (`imported`, `createdAt`, `attachments`) from the issue were left out as explicitly lower priority.

## Verification

- `bun run typecheck`, `bun run lint`, `bun test` (34 pass), `bun run build` all green.
- Verified built CLI: `note --help` shows the flag; an invalid value (`--status bogus`) fails with a clean validation error before any API call.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)