### PR TITLE
feat(mcp): expose full HelpScout triage tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,11 @@ helpscout mcp
 
 The MCP server exposes:
 
-- Typed tools for Help Scout search, mailbox/customer/user lookup, and safe draft-note mutations
+- Typed tools for Help Scout search, full conversation detail, full conversation thread history, mailbox/customer/user lookup, and safe draft-note/status mutations
+- `get_conversation` accepts internal conversation IDs or visible ticket numbers like `#12345`
+- `get_conversation_threads` returns all Help Scout thread types by default, including notes, workflow events, status events, and other system events returned by Help Scout
+- `update_conversation_status` safely changes ticket status, with `open` normalized to Help Scout's `active` status
+- `create_note` adds private notes and can optionally set the ticket status, such as closing no-action tickets
 - User lookup tools expose Help Scout mention handles for composing `@mention` references
 - Resource templates for `helpscout://conversation/{conversationId}`, `helpscout://customer/{customerId}`, and `helpscout://user/{userId}`
 - Prompt templates for `summarize_ticket` and `draft_reply`

--- a/biome.json
+++ b/biome.json
@@ -1,13 +1,12 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "include": ["src/**/*.ts"],
-    "ignore": ["dist", "node_modules"]
+    "includes": ["src/**/*.ts", "!dist", "!node_modules"]
   },
   "formatter": {
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/helpscout-cli",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "A command-line interface for Help Scout",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/commands/conversations.ts
+++ b/src/commands/conversations.ts
@@ -203,7 +203,10 @@ export function createConversationsCommand(): Command {
     .argument('<id>', 'Conversation ID, or ticket number prefixed with "#" (e.g. "#12345")')
     .action(
       withErrorHandling(async (id: string) => {
-        const conversation = await client.getConversation(await client.resolveConversationId(id), 'threads');
+        const conversation = await client.getConversation(
+          await client.resolveConversationId(id),
+          'threads'
+        );
         const threadInfo = extractThreadInfo(conversation._embedded?.threads);
         const result = {
           ...conversation,
@@ -269,7 +272,10 @@ export function createConversationsCommand(): Command {
     .action(
       withErrorHandling(async (id: string, status: string) => {
         const normalizedStatus = normalizeConversationStatus(status);
-        await client.updateConversationStatus(await client.resolveConversationId(id), normalizedStatus);
+        await client.updateConversationStatus(
+          await client.resolveConversationId(id),
+          normalizedStatus
+        );
         outputJson({ message: 'Conversation status updated', status: normalizedStatus });
       })
     );
@@ -300,7 +306,9 @@ export function createConversationsCommand(): Command {
 
   cmd
     .command('draft-reply')
-    .description('Create a draft reply on an existing conversation (never sends — review and send from the Help Scout UI)')
+    .description(
+      'Create a draft reply on an existing conversation (never sends — review and send from the Help Scout UI)'
+    )
     .argument('<id>', 'Conversation ID, or ticket number prefixed with "#" (e.g. "#12345")')
     .requiredOption('--text <text>', 'Reply text')
     .option('--user <id>', 'User ID authoring the draft')
@@ -324,7 +332,9 @@ export function createConversationsCommand(): Command {
 
   cmd
     .command('draft-conversation')
-    .description('Create a new outbound draft conversation (never sends — review and send from the Help Scout UI)')
+    .description(
+      'Create a new outbound draft conversation (never sends — review and send from the Help Scout UI)'
+    )
     .requiredOption('--mailbox <id>', 'Mailbox ID to create the conversation in')
     .requiredOption('--customer-email <email>', 'Recipient customer email address')
     .requiredOption('--subject <subject>', 'Conversation subject')
@@ -366,7 +376,10 @@ export function createConversationsCommand(): Command {
     .argument('<id>', 'Conversation ID, or ticket number prefixed with "#" (e.g. "#12345")')
     .requiredOption('--text <text>', 'Note text')
     .option('--user <id>', 'User ID adding the note')
-    .option('--status <status>', 'Set conversation status after adding the note (active, open, pending, closed, spam)')
+    .option(
+      '--status <status>',
+      'Set conversation status after adding the note (active, open, pending, closed, spam)'
+    )
     .action(
       withErrorHandling(
         async (
@@ -377,9 +390,7 @@ export function createConversationsCommand(): Command {
             status?: string;
           }
         ) => {
-          const status = options.status
-            ? normalizeConversationStatus(options.status)
-            : undefined;
+          const status = options.status ? normalizeConversationStatus(options.status) : undefined;
           await client.createNote(await client.resolveConversationId(id), {
             text: options.text,
             user: options.user ? parseIdArg(options.user, 'user') : undefined,

--- a/src/commands/users.ts
+++ b/src/commands/users.ts
@@ -13,20 +13,14 @@ export function createUsersCommand(): Command {
     .option('-m, --mailbox <id>', 'Filter by mailbox ID')
     .option('--page <number>', 'Page number')
     .action(
-      withErrorHandling(
-        async (options: {
-          email?: string;
-          mailbox?: string;
-          page?: string;
-        }) => {
-          const result = await client.listUsers({
-            email: options.email,
-            mailbox: options.mailbox ? parseIdArg(options.mailbox, 'mailbox') : undefined,
-            page: options.page ? parseInt(options.page, 10) : undefined,
-          });
-          outputJson(result);
-        }
-      )
+      withErrorHandling(async (options: { email?: string; mailbox?: string; page?: string }) => {
+        const result = await client.listUsers({
+          email: options.email,
+          mailbox: options.mailbox ? parseIdArg(options.mailbox, 'mailbox') : undefined,
+          page: options.page ? parseInt(options.page, 10) : undefined,
+        });
+        outputJson(result);
+      })
     );
 
   cmd

--- a/src/commands/workflows.ts
+++ b/src/commands/workflows.ts
@@ -13,20 +13,14 @@ export function createWorkflowsCommand(): Command {
     .option('-t, --type <type>', 'Filter by type (manual, automatic)')
     .option('--page <number>', 'Page number')
     .action(
-      withErrorHandling(
-        async (options: {
-          mailbox?: string;
-          type?: string;
-          page?: string;
-        }) => {
-          const result = await client.listWorkflows({
-            mailbox: options.mailbox ? parseIdArg(options.mailbox, 'mailbox') : undefined,
-            type: options.type,
-            page: options.page ? parseInt(options.page, 10) : undefined,
-          });
-          outputJson(result);
-        }
-      )
+      withErrorHandling(async (options: { mailbox?: string; type?: string; page?: string }) => {
+        const result = await client.listWorkflows({
+          mailbox: options.mailbox ? parseIdArg(options.mailbox, 'mailbox') : undefined,
+          type: options.type,
+          page: options.page ? parseInt(options.page, 10) : undefined,
+        });
+        outputJson(result);
+      })
     );
 
   cmd

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HelpScoutClient } from './api-client.js';
+
+function thread(id: number, type = 'customer') {
+  return {
+    id,
+    type,
+    body: `<p>Thread ${id}</p>`,
+    createdAt: `2026-06-0${id}T00:00:00Z`,
+  };
+}
+
+function paginatedThreads(threads: ReturnType<typeof thread>[], page: number, totalPages: number) {
+  return Response.json({
+    _embedded: { threads },
+    page: {
+      size: threads.length,
+      totalElements: 3,
+      totalPages,
+      number: page,
+    },
+  });
+}
+
+describe('HelpScoutClient', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let client: HelpScoutClient;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    client = new HelpScoutClient({
+      getAccessToken: vi.fn().mockResolvedValue('test-token'),
+      getAppId: vi.fn().mockResolvedValue('app-id'),
+      getAppSecret: vi.fn().mockResolvedValue('app-secret'),
+      getRefreshToken: vi.fn().mockResolvedValue(null),
+      setAccessToken: vi.fn().mockResolvedValue(true),
+      setRefreshToken: vi.fn().mockResolvedValue(true),
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.resetAllMocks();
+  });
+
+  it('fetches all conversation thread pages', async () => {
+    fetchMock
+      .mockResolvedValueOnce(paginatedThreads([thread(1)], 1, 2))
+      .mockResolvedValueOnce(paginatedThreads([thread(2, 'note'), thread(3, 'lineitem')], 2, 2));
+
+    const threads = await client.getConversationThreads(123);
+
+    expect(threads).toEqual([thread(1), thread(2, 'note'), thread(3, 'lineitem')]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.helpscout.net/v2/conversations/123/threads?page=1'
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://api.helpscout.net/v2/conversations/123/threads?page=2'
+    );
+  });
+
+  it('stops fetching thread pages after maxResults is reached', async () => {
+    fetchMock.mockResolvedValueOnce(paginatedThreads([thread(1), thread(2, 'note')], 1, 2));
+
+    const threads = await client.getConversationThreads(123, 1);
+
+    expect(threads).toEqual([thread(1)]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends a status patch request', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await client.updateConversationStatus(123, 'closed');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.helpscout.net/v2/conversations/123',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ op: 'replace', path: '/status', value: 'closed' }),
+      })
+    );
+  });
+
+  it('sends private notes with optional status', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 201 }));
+
+    await client.createNote(123, { text: 'No action needed.', status: 'closed' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.helpscout.net/v2/conversations/123/notes',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ text: 'No action needed.', status: 'closed' }),
+      })
+    );
+  });
+});

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -28,17 +28,28 @@ interface PaginatedResponse<T> {
   page: PageInfo;
 }
 
+interface AuthProvider {
+  getAccessToken(): Promise<string | null>;
+  setAccessToken(token: string): Promise<boolean>;
+  getRefreshToken(): Promise<string | null>;
+  setRefreshToken(token: string): Promise<boolean>;
+  getAppId(): Promise<string | null>;
+  getAppSecret(): Promise<string | null>;
+}
+
 export class HelpScoutClient {
   private accessToken: string | null = null;
+
+  constructor(private readonly authManager: AuthProvider = auth) {}
 
   clearToken(): void {
     this.accessToken = null;
   }
 
   async refreshAccessToken(): Promise<string> {
-    const appId = await auth.getAppId();
-    const appSecret = await auth.getAppSecret();
-    const refreshToken = await auth.getRefreshToken();
+    const appId = await this.authManager.getAppId();
+    const appSecret = await this.authManager.getAppSecret();
+    const refreshToken = await this.authManager.getRefreshToken();
 
     if (!appId || !appSecret) {
       throw new HelpScoutCliError('Not configured. Please run: helpscout auth login', 401);
@@ -59,9 +70,9 @@ export class HelpScoutClient {
 
         if (response.ok) {
           const data = (await response.json()) as TokenResponse;
-          await auth.setAccessToken(data.access_token);
+          await this.authManager.setAccessToken(data.access_token);
           if (data.refresh_token) {
-            await auth.setRefreshToken(data.refresh_token);
+            await this.authManager.setRefreshToken(data.refresh_token);
           }
           this.accessToken = data.access_token;
           return data.access_token;
@@ -99,7 +110,7 @@ export class HelpScoutClient {
     }
 
     const data = (await response.json()) as TokenResponse;
-    await auth.setAccessToken(data.access_token);
+    await this.authManager.setAccessToken(data.access_token);
     this.accessToken = data.access_token;
     return data.access_token;
   }
@@ -109,7 +120,7 @@ export class HelpScoutClient {
       return this.accessToken;
     }
 
-    const storedToken = await auth.getAccessToken();
+    const storedToken = await this.authManager.getAccessToken();
     if (storedToken) {
       this.accessToken = storedToken;
       return storedToken;
@@ -197,7 +208,13 @@ export class HelpScoutClient {
     if (response.status === 204) {
       return {} as T;
     }
-    return response.json() as Promise<T>;
+
+    const text = await response.text();
+    if (!text) {
+      return {} as T;
+    }
+
+    return JSON.parse(text) as T;
   }
 
   // Conversations
@@ -234,7 +251,7 @@ export class HelpScoutClient {
       query?: string;
       embed?: string;
     } = {},
-    maxResults?: number,
+    maxResults?: number
   ): Promise<Conversation[]> {
     const allConversations: Conversation[] = [];
     let page = 1;
@@ -294,12 +311,28 @@ export class HelpScoutClient {
     return parsed;
   }
 
-  async getConversationThreads(conversationId: number) {
-    const response = await this.request<PaginatedResponse<{ threads: Thread[] }>>(
-      'GET',
-      `/conversations/${conversationId}/threads`
-    );
-    return response._embedded?.threads || [];
+  async getConversationThreads(conversationId: number, maxResults?: number) {
+    const threads: Thread[] = [];
+    let page = 1;
+    let totalPages = 1;
+
+    do {
+      const response = await this.request<PaginatedResponse<{ threads: Thread[] }>>(
+        'GET',
+        `/conversations/${conversationId}/threads`,
+        { params: { page } }
+      );
+
+      threads.push(...(response._embedded?.threads || []));
+      if (maxResults && threads.length >= maxResults) {
+        return threads.slice(0, maxResults);
+      }
+
+      totalPages = response.page.totalPages;
+      page++;
+    } while (page <= totalPages);
+
+    return threads;
   }
 
   async updateConversation(
@@ -314,7 +347,11 @@ export class HelpScoutClient {
   }
 
   async updateConversationStatus(conversationId: number, status: ConversationStatus) {
-    await this.updateConversation(conversationId, { op: 'replace', path: '/status', value: status });
+    await this.updateConversation(conversationId, {
+      op: 'replace',
+      path: '/status',
+      value: status,
+    });
   }
 
   async deleteConversation(conversationId: number) {
@@ -358,7 +395,16 @@ export class HelpScoutClient {
     user?: number;
     tags?: string[];
   }): Promise<{ id: number }> {
-    const { subject, mailboxId, customerEmail, text, type = 'email', status = 'active', user, tags } = data;
+    const {
+      subject,
+      mailboxId,
+      customerEmail,
+      text,
+      type = 'email',
+      status = 'active',
+      user,
+      tags,
+    } = data;
     const response = await this.rawRequest('POST', '/conversations', {
       body: {
         subject,
@@ -384,7 +430,7 @@ export class HelpScoutClient {
     if (!match) {
       throw new HelpScoutCliError(
         'Draft conversation created but could not parse ID from Location header',
-        0,
+        0
       );
     }
     return { id: parseInt(match[1], 10) };
@@ -456,13 +502,7 @@ export class HelpScoutClient {
   }
 
   // Users
-  async listUsers(
-    params: {
-      email?: string;
-      mailbox?: number;
-      page?: number;
-    } = {}
-  ) {
+  async listUsers(params: { email?: string; mailbox?: number; page?: number } = {}) {
     const response = await this.request<PaginatedResponse<{ users: User[] }>>('GET', '/users', {
       params,
     });
@@ -492,13 +532,7 @@ export class HelpScoutClient {
   }
 
   // Workflows
-  async listWorkflows(
-    params: {
-      mailbox?: number;
-      type?: string;
-      page?: number;
-    } = {}
-  ) {
+  async listWorkflows(params: { mailbox?: number; type?: string; page?: number } = {}) {
     const response = await this.request<PaginatedResponse<{ workflows: Workflow[] }>>(
       'GET',
       '/workflows',

--- a/src/lib/command-utils.ts
+++ b/src/lib/command-utils.ts
@@ -29,9 +29,6 @@ export function requireAtLeastOneField(data: Record<string, unknown>, operation:
 
 export function requireConfirmation(itemType: string, confirmed: boolean = false): void {
   if (!confirmed) {
-    throw new HelpScoutCliError(
-      `Deleting ${itemType} requires --yes flag to confirm`,
-      400
-    );
+    throw new HelpScoutCliError(`Deleting ${itemType} requires --yes flag to confirm`, 400);
   }
 }

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -25,9 +25,7 @@ describe('normalizeSearchQuery', () => {
   });
 
   it('should pass through mixed explicit operators', () => {
-    expect(normalizeSearchQuery('audio AND latency OR video')).toBe(
-      'audio AND latency OR video'
-    );
+    expect(normalizeSearchQuery('audio AND latency OR video')).toBe('audio AND latency OR video');
   });
 
   it('should not transform a single token', () => {

--- a/src/mcp/conversation-threads.test.ts
+++ b/src/mcp/conversation-threads.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { Thread } from '../types/index.js';
+import { buildConversationThreadsResult, filterThreadsByType } from './conversation-threads.js';
+
+function thread(id: number, type: string): Thread {
+  return {
+    id,
+    type,
+    body: `<p>${type} ${id}</p>`,
+    createdAt: `2026-06-0${id}T00:00:00Z`,
+  };
+}
+
+describe('conversation thread MCP helpers', () => {
+  it('filters thread history by requested type', () => {
+    const threads = [thread(1, 'customer'), thread(2, 'note'), thread(3, 'lineitem')];
+
+    expect(filterThreadsByType(threads, [' NOTE ', 'lineitem'])).toEqual([
+      thread(2, 'note'),
+      thread(3, 'lineitem'),
+    ]);
+  });
+
+  it('builds uncapped all-type thread results by default', () => {
+    const threads = [thread(1, 'customer'), thread(2, 'note'), thread(3, 'lineitem')];
+
+    expect(buildConversationThreadsResult(123, threads)).toEqual({
+      conversationId: 123,
+      threads,
+      total_threads: 3,
+      matching_threads: 3,
+      returned_threads: 3,
+    });
+  });
+
+  it('reports filtering and cap metadata', () => {
+    const threads = [thread(1, 'customer'), thread(2, 'note'), thread(3, 'note')];
+
+    expect(
+      buildConversationThreadsResult(123, threads, {
+        types: ['note'],
+        maxThreads: 1,
+      })
+    ).toEqual({
+      conversationId: 123,
+      threads: [thread(2, 'note')],
+      total_threads: 3,
+      matching_threads: 2,
+      returned_threads: 1,
+      omitted_threads: 1,
+      filtered_types: ['note'],
+    });
+  });
+});

--- a/src/mcp/conversation-threads.ts
+++ b/src/mcp/conversation-threads.ts
@@ -1,0 +1,47 @@
+import type { Thread } from '../types/index.js';
+
+export interface ConversationThreadsOptions {
+  types?: string[];
+  maxThreads?: number;
+  cleanThreads?: (threads: Thread[]) => unknown[];
+}
+
+export function normalizeThreadTypes(types: string[] | undefined): string[] | undefined {
+  if (!types?.length) return undefined;
+
+  const normalized = types.map((type) => type.trim().toLowerCase()).filter(Boolean);
+  return normalized.length ? normalized : undefined;
+}
+
+export function filterThreadsByType(threads: Thread[], types: string[] | undefined): Thread[] {
+  const normalizedTypes = normalizeThreadTypes(types);
+  if (!normalizedTypes) return threads;
+
+  const allowedTypes = new Set(normalizedTypes);
+  return threads.filter((thread) => allowedTypes.has(thread.type.toLowerCase()));
+}
+
+export function buildConversationThreadsResult(
+  conversationId: number,
+  threads: Thread[],
+  options: ConversationThreadsOptions = {}
+) {
+  const filteredTypes = normalizeThreadTypes(options.types);
+  const matchingThreads = filterThreadsByType(threads, filteredTypes);
+  const limitedThreads = options.maxThreads
+    ? matchingThreads.slice(0, options.maxThreads)
+    : matchingThreads;
+  const cleanThreads = options.cleanThreads ?? ((items: Thread[]) => items);
+
+  return {
+    conversationId,
+    threads: cleanThreads(limitedThreads),
+    total_threads: threads.length,
+    matching_threads: matchingThreads.length,
+    returned_threads: limitedThreads.length,
+    ...(limitedThreads.length < matchingThreads.length && {
+      omitted_threads: matchingThreads.length - limitedThreads.length,
+    }),
+    ...(filteredTypes && { filtered_types: filteredTypes }),
+  };
+}

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,0 +1,31 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+let mcpServer: typeof import('./server.js');
+
+beforeAll(async () => {
+  Object.assign(globalThis, {
+    __VERSION__: 'test',
+    __HOMEPAGE__: '',
+  });
+  mcpServer = await import('./server.js');
+});
+
+afterAll(() => {
+  delete (globalThis as { __VERSION__?: string }).__VERSION__;
+  delete (globalThis as { __HOMEPAGE__?: string }).__HOMEPAGE__;
+});
+
+describe('Help Scout MCP server helpers', () => {
+  it('registers the conversation tools needed for GTD triage', () => {
+    const toolNames = mcpServer.getRegisteredToolsForTesting().map((tool) => tool.name);
+
+    expect(toolNames).toEqual(
+      expect.arrayContaining([
+        'get_conversation',
+        'get_conversation_threads',
+        'update_conversation_status',
+        'create_note',
+      ])
+    );
+  });
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -6,6 +6,7 @@ import { auth } from '../lib/auth.js';
 import { normalizeConversationStatus } from '../lib/conversation-status.js';
 import { buildDateQuery } from '../lib/dates.js';
 import { normalizeSearchQuery } from '../lib/search.js';
+import { buildConversationThreadsResult } from './conversation-threads.js';
 import type {
   Conversation,
   Customer,
@@ -46,8 +47,10 @@ function cleanForMcp(data: unknown): unknown {
   for (const [key, value] of Object.entries(obj)) {
     if (key === '_links') continue;
     if (key === 'photoUrl') continue;
-    if (key === 'color' && Object.keys(obj).includes('name') && Object.keys(obj).includes('slug')) continue; // tag style
-    if (key === 'styles' && Object.keys(obj).includes('name') && Object.keys(obj).includes('slug')) continue; // tag style
+    if (key === 'color' && Object.keys(obj).includes('name') && Object.keys(obj).includes('slug'))
+      continue; // tag style
+    if (key === 'styles' && Object.keys(obj).includes('name') && Object.keys(obj).includes('slug'))
+      continue; // tag style
 
     // Strip zero-valued IDs (Help Scout placeholder convention)
     if (key === 'id' && value === 0) continue;
@@ -128,7 +131,7 @@ function resourceLinkContent(uri: string, name: string, description: string): Re
 
 function structuredJsonResult<T extends JsonObject>(
   structuredContent: T,
-  extraContent: ResourceLinkBlock[] = [],
+  extraContent: ResourceLinkBlock[] = []
 ) {
   return {
     content: [jsonTextContent(structuredContent), ...extraContent],
@@ -163,9 +166,7 @@ function capThreads(threads: Thread[], maxThreads: number) {
     return { threads: cleanForMcp(threads) as unknown[] };
   }
 
-  const kept = maxThreads <= 1
-    ? [threads[0]]
-    : [threads[0], ...threads.slice(-(maxThreads - 1))];
+  const kept = maxThreads <= 1 ? [threads[0]] : [threads[0], ...threads.slice(-(maxThreads - 1))];
 
   return {
     threads: cleanForMcp(kept) as unknown[],
@@ -178,7 +179,7 @@ function capThreads(threads: Thread[], maxThreads: number) {
 async function getConversationDetail(
   conversationId: number,
   includeThreads = false,
-  maxThreads = DEFAULT_MAX_THREADS,
+  maxThreads = DEFAULT_MAX_THREADS
 ) {
   const conversation = await client.getConversation(conversationId);
   const detail: JsonObject = { conversation: normalizeConversation(conversation) };
@@ -233,172 +234,232 @@ const pageInfoSchema = z.object({
   number: z.number(),
 });
 
-const personSchema = z.object({
-  id: z.number().optional(),
-  type: z.string().optional(),
-  email: z.string().optional(),
-  name: z.string().optional(),
-}).passthrough();
-
-const sourceSchema = z.object({
-  type: z.string(),
-  via: z.string(),
-}).passthrough();
-
-const tagSchema = z.object({
-  id: z.number().optional(),
-  name: z.string().optional(),
-  slug: z.string().optional(),
-  tag: z.string().optional(),
-  color: z.string().optional(),
-  createdAt: z.string().optional(),
-  updatedAt: z.string().optional(),
-  ticketCount: z.number().optional(),
-}).passthrough();
-
-const customFieldSchema = z.object({
-  id: z.number().optional(),
-  name: z.string(),
-  value: z.string(),
-  type: z.string(),
-}).passthrough();
-
-const conversationSchema = z.object({
-  id: z.number(),
-  number: z.number(),
-  type: z.string(),
-  folderId: z.number().optional(),
-  status: z.string(),
-  state: z.string(),
-  subject: z.string(),
-  preview: z.string(),
-  mailboxId: z.number(),
-  assignee: personSchema.optional(),
-  createdBy: personSchema.optional(),
-  createdAt: z.string(),
-  closedAt: z.string().optional(),
-  closedBy: z.number().optional(),
-  modifiedAt: z.string().optional(),
-  customerWaitingSince: z.object({
-    time: z.string(),
-    friendly: z.string(),
-  }).optional(),
-  source: sourceSchema.optional(),
-  tags: z.array(tagSchema).optional(),
-  cc: z.array(z.string()).optional(),
-  bcc: z.array(z.string()).optional(),
-  primaryCustomer: personSchema.optional(),
-  customFields: z.array(customFieldSchema).optional(),
-  threadCount: z.number().optional(),
-}).passthrough();
-
-const threadSchema = z.object({
-  id: z.number().optional(),
-  type: z.string(),
-  // Not present on every thread type (e.g. lineitem and other system-generated
-  // threads omit them), so these are optional rather than required.
-  status: z.string().optional(),
-  state: z.string().optional(),
-  action: z.object({
-    type: z.string(),
-    text: z.string().optional(),
-  }).optional(),
-  body: z.string().optional(),
-  source: sourceSchema.optional(),
-  customer: personSchema.optional(),
-  createdBy: personSchema.optional(),
-  assignedTo: personSchema.optional(),
-  savedReplyId: z.number().optional(),
-  to: z.array(z.string()).optional(),
-  cc: z.array(z.string()).optional(),
-  bcc: z.array(z.string()).optional(),
-  createdAt: z.string(),
-  openedAt: z.string().optional(),
-}).passthrough();
-
-const customerSchema = z.object({
-  id: z.number(),
-  firstName: z.string().optional(),
-  lastName: z.string().optional(),
-  gender: z.string().optional(),
-  jobTitle: z.string().optional(),
-  location: z.string().optional(),
-  organization: z.string().optional(),
-  photoType: z.string().optional(),
-  background: z.string().optional(),
-  age: z.string().optional(),
-  createdAt: z.string(),
-  updatedAt: z.string().optional(),
-  emails: z.array(z.object({
+const personSchema = z
+  .object({
     id: z.number().optional(),
+    type: z.string().optional(),
+    email: z.string().optional(),
+    name: z.string().optional(),
+  })
+  .passthrough();
+
+const sourceSchema = z
+  .object({
+    type: z.string(),
+    via: z.string(),
+  })
+  .passthrough();
+
+const tagSchema = z
+  .object({
+    id: z.number().optional(),
+    name: z.string().optional(),
+    slug: z.string().optional(),
+    tag: z.string().optional(),
+    color: z.string().optional(),
+    createdAt: z.string().optional(),
+    updatedAt: z.string().optional(),
+    ticketCount: z.number().optional(),
+  })
+  .passthrough();
+
+const customFieldSchema = z
+  .object({
+    id: z.number().optional(),
+    name: z.string(),
     value: z.string(),
     type: z.string(),
-  }).passthrough()).optional(),
-  phones: z.array(z.object({
-    id: z.number().optional(),
-    value: z.string(),
+  })
+  .passthrough();
+
+const conversationSchema = z
+  .object({
+    id: z.number(),
+    number: z.number(),
     type: z.string(),
-  }).passthrough()).optional(),
-  chats: z.array(z.object({
+    folderId: z.number().optional(),
+    status: z.string(),
+    state: z.string(),
+    subject: z.string(),
+    preview: z.string(),
+    mailboxId: z.number(),
+    assignee: personSchema.optional(),
+    createdBy: personSchema.optional(),
+    createdAt: z.string(),
+    closedAt: z.string().optional(),
+    closedBy: z.number().optional(),
+    modifiedAt: z.string().optional(),
+    customerWaitingSince: z
+      .object({
+        time: z.string(),
+        friendly: z.string(),
+      })
+      .optional(),
+    source: sourceSchema.optional(),
+    tags: z.array(tagSchema).optional(),
+    cc: z.array(z.string()).optional(),
+    bcc: z.array(z.string()).optional(),
+    primaryCustomer: personSchema.optional(),
+    customFields: z.array(customFieldSchema).optional(),
+    threadCount: z.number().optional(),
+  })
+  .passthrough();
+
+const threadSchema = z
+  .object({
     id: z.number().optional(),
-    value: z.string(),
     type: z.string(),
-  }).passthrough()).optional(),
-  socialProfiles: z.array(z.object({
-    id: z.number().optional(),
-    value: z.string(),
-    type: z.string(),
-  }).passthrough()).optional(),
-  websites: z.array(z.object({
-    id: z.number().optional(),
-    value: z.string(),
-  }).passthrough()).optional(),
-  addresses: z.array(z.object({
-    id: z.number().optional(),
-    city: z.string().optional(),
+    // Not present on every thread type (e.g. lineitem and other system-generated
+    // threads omit them), so these are optional rather than required.
+    status: z.string().optional(),
     state: z.string().optional(),
-    postalCode: z.string().optional(),
-    country: z.string().optional(),
-    lines: z.array(z.string()).optional(),
-  }).passthrough()).optional(),
-}).passthrough();
+    action: z
+      .object({
+        type: z.string(),
+        text: z.string().optional(),
+      })
+      .optional(),
+    body: z.string().optional(),
+    source: sourceSchema.optional(),
+    customer: personSchema.optional(),
+    createdBy: personSchema.optional(),
+    assignedTo: personSchema.optional(),
+    savedReplyId: z.number().optional(),
+    to: z.array(z.string()).optional(),
+    cc: z.array(z.string()).optional(),
+    bcc: z.array(z.string()).optional(),
+    createdAt: z.string(),
+    openedAt: z.string().optional(),
+  })
+  .passthrough();
 
-const userSchema = z.object({
-  id: z.number(),
-  firstName: z.string().optional(),
-  lastName: z.string().optional(),
-  email: z.string().optional(),
-  role: z.string().optional(),
-  timezone: z.string().optional(),
-  createdAt: z.string().optional(),
-  updatedAt: z.string().optional(),
-  type: z.string().optional(),
-  mention: z.string().optional(),
-  initials: z.string().optional(),
-  jobTitle: z.string().optional(),
-  phone: z.string().optional(),
-  alternateEmails: z.array(z.string()).optional(),
-}).passthrough();
+const customerSchema = z
+  .object({
+    id: z.number(),
+    firstName: z.string().optional(),
+    lastName: z.string().optional(),
+    gender: z.string().optional(),
+    jobTitle: z.string().optional(),
+    location: z.string().optional(),
+    organization: z.string().optional(),
+    photoType: z.string().optional(),
+    background: z.string().optional(),
+    age: z.string().optional(),
+    createdAt: z.string(),
+    updatedAt: z.string().optional(),
+    emails: z
+      .array(
+        z
+          .object({
+            id: z.number().optional(),
+            value: z.string(),
+            type: z.string(),
+          })
+          .passthrough()
+      )
+      .optional(),
+    phones: z
+      .array(
+        z
+          .object({
+            id: z.number().optional(),
+            value: z.string(),
+            type: z.string(),
+          })
+          .passthrough()
+      )
+      .optional(),
+    chats: z
+      .array(
+        z
+          .object({
+            id: z.number().optional(),
+            value: z.string(),
+            type: z.string(),
+          })
+          .passthrough()
+      )
+      .optional(),
+    socialProfiles: z
+      .array(
+        z
+          .object({
+            id: z.number().optional(),
+            value: z.string(),
+            type: z.string(),
+          })
+          .passthrough()
+      )
+      .optional(),
+    websites: z
+      .array(
+        z
+          .object({
+            id: z.number().optional(),
+            value: z.string(),
+          })
+          .passthrough()
+      )
+      .optional(),
+    addresses: z
+      .array(
+        z
+          .object({
+            id: z.number().optional(),
+            city: z.string().optional(),
+            state: z.string().optional(),
+            postalCode: z.string().optional(),
+            country: z.string().optional(),
+            lines: z.array(z.string()).optional(),
+          })
+          .passthrough()
+      )
+      .optional(),
+  })
+  .passthrough();
 
-const mailboxSchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  slug: z.string(),
-  email: z.string(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-}).passthrough();
+const userSchema = z
+  .object({
+    id: z.number(),
+    firstName: z.string().optional(),
+    lastName: z.string().optional(),
+    email: z.string().optional(),
+    role: z.string().optional(),
+    timezone: z.string().optional(),
+    createdAt: z.string().optional(),
+    updatedAt: z.string().optional(),
+    type: z.string().optional(),
+    mention: z.string().optional(),
+    initials: z.string().optional(),
+    jobTitle: z.string().optional(),
+    phone: z.string().optional(),
+    alternateEmails: z.array(z.string()).optional(),
+  })
+  .passthrough();
 
-const workflowSchema = z.object({
-  id: z.number(),
-  mailboxId: z.number(),
-  type: z.string(),
-  status: z.string(),
-  order: z.number(),
-  name: z.string(),
-  createdAt: z.string(),
-  modifiedAt: z.string(),
-}).passthrough();
+const mailboxSchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+    slug: z.string(),
+    email: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .passthrough();
+
+const workflowSchema = z
+  .object({
+    id: z.number(),
+    mailboxId: z.number(),
+    type: z.string(),
+    status: z.string(),
+    order: z.number(),
+    name: z.string(),
+    createdAt: z.string(),
+    modifiedAt: z.string(),
+  })
+  .passthrough();
 
 const listConversationsOutputSchema = z.object({
   conversations: z.array(conversationSchema),
@@ -411,6 +472,16 @@ const conversationDetailOutputSchema = z.object({
   total_threads: z.number().optional(),
   returned_threads: z.number().optional(),
   omitted_threads: z.number().optional(),
+});
+
+const conversationThreadsOutputSchema = z.object({
+  conversationId: z.number(),
+  threads: z.array(threadSchema),
+  total_threads: z.number(),
+  matching_threads: z.number(),
+  returned_threads: z.number(),
+  omitted_threads: z.number().optional(),
+  filtered_types: z.array(z.string()).optional(),
 });
 
 const searchConversationsOutputSchema = z.object({
@@ -427,7 +498,9 @@ const searchConversationsOutputSchema = z.object({
  */
 const conversationRefSchema = z
   .union([z.number().int().positive(), z.string().min(1)])
-  .describe('Conversation ID (internal numeric id), or visible ticket number prefixed with "#" (e.g. "#12345")');
+  .describe(
+    'Conversation ID (internal numeric id), or visible ticket number prefixed with "#" (e.g. "#12345")'
+  );
 
 const searchByCustomerOutputSchema = searchConversationsOutputSchema.extend({
   meta: z.object({
@@ -550,11 +623,33 @@ function rememberTool(name: string, description: string) {
   toolRegistry.push({ name, description });
 }
 
+export function getRegisteredToolsForTesting() {
+  return [...toolRegistry];
+}
+
 const dateFilterSchema = {
-  createdSince: z.string().optional().describe('Filter by creation date — returns only conversations created after this date. Does not include older conversations with recent activity; use modifiedSince for that.'),
-  createdBefore: z.string().optional().describe('Filter by creation date — returns only conversations created before this date'),
-  modifiedSince: z.string().optional().describe('Filter by last activity date — returns conversations with ANY activity (replies, notes, status changes, tag changes) after this date, including old conversations. Use createdSince to filter by creation date instead.'),
-  modifiedBefore: z.string().optional().describe('Filter by last activity date — returns conversations with last activity before this date'),
+  createdSince: z
+    .string()
+    .optional()
+    .describe(
+      'Filter by creation date — returns only conversations created after this date. Does not include older conversations with recent activity; use modifiedSince for that.'
+    ),
+  createdBefore: z
+    .string()
+    .optional()
+    .describe('Filter by creation date — returns only conversations created before this date'),
+  modifiedSince: z
+    .string()
+    .optional()
+    .describe(
+      'Filter by last activity date — returns conversations with ANY activity (replies, notes, status changes, tag changes) after this date, including old conversations. Use createdSince to filter by creation date instead.'
+    ),
+  modifiedBefore: z
+    .string()
+    .optional()
+    .describe(
+      'Filter by last activity date — returns conversations with last activity before this date'
+    ),
 };
 
 const GENERIC_EMAIL_DOMAINS = new Set([
@@ -588,7 +683,7 @@ server.registerResource(
     const conversationId = parseTemplateNumber(variables.conversationId, 'conversationId');
     const detail = await getConversationDetail(conversationId, true, DEFAULT_MAX_THREADS);
     return buildJsonResource(uri.toString(), detail);
-  },
+  }
 );
 
 server.registerResource(
@@ -603,7 +698,7 @@ server.registerResource(
     const customerId = parseTemplateNumber(variables.customerId, 'customerId');
     const customer = cleanCustomer(await client.getCustomer(customerId));
     return buildJsonResource(uri.toString(), customer);
-  },
+  }
 );
 
 server.registerResource(
@@ -618,7 +713,7 @@ server.registerResource(
     const userId = parseTemplateNumber(variables.userId, 'userId');
     const user = cleanUser(await client.getUser(userId));
     return buildJsonResource(uri.toString(), user);
-  },
+  }
 );
 
 server.registerPrompt(
@@ -628,8 +723,15 @@ server.registerPrompt(
     description: 'Generate an internal summary of a Help Scout conversation.',
     argsSchema: {
       conversationId: z.number().describe('Conversation ID to summarize'),
-      focus: z.string().optional().describe('Optional area to emphasize, such as billing, bugs, or customer sentiment'),
-      maxThreads: z.number().optional().default(DEFAULT_MAX_THREADS).describe('Maximum threads to include in the prompt context (default 20)'),
+      focus: z
+        .string()
+        .optional()
+        .describe('Optional area to emphasize, such as billing, bugs, or customer sentiment'),
+      maxThreads: z
+        .number()
+        .optional()
+        .default(DEFAULT_MAX_THREADS)
+        .describe('Maximum threads to include in the prompt context (default 20)'),
     },
   },
   async ({ conversationId, focus, maxThreads }) => {
@@ -656,7 +758,7 @@ server.registerPrompt(
         },
       ],
     };
-  },
+  }
 );
 
 server.registerPrompt(
@@ -666,9 +768,21 @@ server.registerPrompt(
     description: 'Draft a customer-facing reply from a Help Scout conversation.',
     argsSchema: {
       conversationId: z.number().describe('Conversation ID to reply to'),
-      tone: z.string().optional().describe('Desired tone, such as concise, warm, direct, or apologetic'),
-      goal: z.string().optional().describe('Specific reply goal, such as resolving billing confusion or asking for a reproduction'),
-      maxThreads: z.number().optional().default(DEFAULT_MAX_THREADS).describe('Maximum threads to include in the prompt context (default 20)'),
+      tone: z
+        .string()
+        .optional()
+        .describe('Desired tone, such as concise, warm, direct, or apologetic'),
+      goal: z
+        .string()
+        .optional()
+        .describe(
+          'Specific reply goal, such as resolving billing confusion or asking for a reproduction'
+        ),
+      maxThreads: z
+        .number()
+        .optional()
+        .default(DEFAULT_MAX_THREADS)
+        .describe('Maximum threads to include in the prompt context (default 20)'),
     },
   },
   async ({ conversationId, tone, goal, maxThreads }) => {
@@ -696,15 +810,19 @@ server.registerPrompt(
         },
       ],
     };
-  },
+  }
 );
 
-rememberTool('list_conversations', 'List conversations with optional filtering by status, mailbox, tag, assignee, or date range');
+rememberTool(
+  'list_conversations',
+  'List conversations with optional filtering by status, mailbox, tag, assignee, or date range'
+);
 server.registerTool(
   'list_conversations',
   {
     title: 'List Conversations',
-    description: 'List conversations with optional filtering by status, mailbox, tag, assignee, or date range',
+    description:
+      'List conversations with optional filtering by status, mailbox, tag, assignee, or date range',
     inputSchema: {
       status: z
         .enum(['active', 'pending', 'closed', 'spam', 'all'])
@@ -713,35 +831,69 @@ server.registerTool(
       mailbox: z.string().optional().describe('Mailbox ID to filter by'),
       tag: z.string().optional().describe('Tag to filter by'),
       assignedTo: z.string().optional().describe('User ID assigned to'),
-      query: z.string().optional().describe('Search query. Multi-word queries are automatically AND-joined unless explicit boolean operators (AND, OR, NOT) are present.'),
+      query: z
+        .string()
+        .optional()
+        .describe(
+          'Search query. Multi-word queries are automatically AND-joined unless explicit boolean operators (AND, OR, NOT) are present.'
+        ),
       page: z.number().optional().describe('Page number'),
       ...dateFilterSchema,
     },
     outputSchema: listConversationsOutputSchema,
     annotations: READ_ONLY_REMOTE_ANNOTATIONS,
   },
-  async ({ status = 'all', mailbox, tag, assignedTo, query, page, createdSince, createdBefore, modifiedSince, modifiedBefore }) => {
+  async ({
+    status = 'all',
+    mailbox,
+    tag,
+    assignedTo,
+    query,
+    page,
+    createdSince,
+    createdBefore,
+    modifiedSince,
+    modifiedBefore,
+  }) => {
     const normalizedQuery = normalizeSearchQuery(query);
-    const dateQuery = buildDateQuery({ createdSince, createdBefore, modifiedSince, modifiedBefore }, normalizedQuery);
-    const result = await client.listConversations({ status, mailbox, tag, assignedTo, query: dateQuery, page });
+    const dateQuery = buildDateQuery(
+      { createdSince, createdBefore, modifiedSince, modifiedBefore },
+      normalizedQuery
+    );
+    const result = await client.listConversations({
+      status,
+      mailbox,
+      tag,
+      assignedTo,
+      query: dateQuery,
+      page,
+    });
 
     return structuredJsonResult({
       conversations: normalizeConversations(result.conversations),
       page: result.page,
     });
-  },
+  }
 );
 
-rememberTool('get_conversation', 'Get detailed information about a specific conversation. When includeThreads is true, the result includes capped threads as a separate array.');
+rememberTool(
+  'get_conversation',
+  'Get detailed information about a specific conversation. When includeThreads is true, the result includes capped threads as a separate array.'
+);
 server.registerTool(
   'get_conversation',
   {
     title: 'Get Conversation',
-    description: 'Get detailed information about a specific conversation. When includeThreads is true, the result includes capped threads as a separate array.',
+    description:
+      'Get detailed information about a specific conversation. When includeThreads is true, the result includes capped threads as a separate array.',
     inputSchema: {
       conversationId: conversationRefSchema,
       includeThreads: z.boolean().optional().describe('Include conversation threads'),
-      maxThreads: z.number().optional().default(DEFAULT_MAX_THREADS).describe('Maximum threads to return (default 20). Keeps original message + most recent.'),
+      maxThreads: z
+        .number()
+        .optional()
+        .default(DEFAULT_MAX_THREADS)
+        .describe('Maximum threads to return (default 20). Keeps original message + most recent.'),
     },
     outputSchema: conversationDetailOutputSchema,
     annotations: READ_ONLY_REMOTE_ANNOTATIONS,
@@ -754,56 +906,162 @@ server.registerTool(
       resourceLinkContent(
         conversationResourceUri(conversationId),
         `Conversation ${conversationId}`,
-        'Detailed Help Scout conversation resource',
+        'Detailed Help Scout conversation resource'
       ),
     ]);
-  },
+  }
 );
 
-rememberTool('search_conversations', 'Search conversations matching a query. Results are capped by maxResults (default 25). If results are truncated, use date filters or more specific search terms to narrow. WARNING: Compound filters are unreliable — use one filter per call.');
+rememberTool(
+  'get_conversation_threads',
+  'Get the full thread history for a conversation, including notes, workflow events, status events, and other system thread types returned by Help Scout. Accepts internal ids or visible ticket numbers like "#12345".'
+);
+server.registerTool(
+  'get_conversation_threads',
+  {
+    title: 'Get Conversation Threads',
+    description:
+      'Get the full thread history for a conversation, including notes, workflow events, status events, and other system thread types returned by Help Scout. Accepts internal ids or visible ticket numbers like "#12345".',
+    inputSchema: {
+      conversationId: conversationRefSchema,
+      types: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Optional thread type filter, such as ["customer", "message", "note", "lineitem"]. Omit to return all thread types.'
+        ),
+      maxThreads: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Optional cap on returned threads. Omit for full history.'),
+    },
+    outputSchema: conversationThreadsOutputSchema,
+    annotations: READ_ONLY_REMOTE_ANNOTATIONS,
+  },
+  async ({ conversationId: conversationRef, types, maxThreads }) => {
+    const conversationId = await client.resolveConversationId(conversationRef);
+    const threads = await client.getConversationThreads(conversationId);
+
+    return structuredJsonResult(
+      buildConversationThreadsResult(conversationId, threads, {
+        types,
+        maxThreads,
+        cleanThreads: (items) => cleanForMcp(items) as unknown[],
+      }),
+      [
+        resourceLinkContent(
+          conversationResourceUri(conversationId),
+          `Conversation ${conversationId}`,
+          'Detailed Help Scout conversation resource'
+        ),
+      ]
+    );
+  }
+);
+
+rememberTool(
+  'search_conversations',
+  'Search conversations matching a query. Results are capped by maxResults (default 25). If results are truncated, use date filters or more specific search terms to narrow. WARNING: Compound filters are unreliable — use one filter per call.'
+);
 server.registerTool(
   'search_conversations',
   {
     title: 'Search Conversations',
-    description: 'Search conversations matching a query. Results are capped by maxResults (default 25). If results are truncated, use date filters or more specific search terms to narrow. WARNING: Compound filters are unreliable — use one filter per call.',
+    description:
+      'Search conversations matching a query. Results are capped by maxResults (default 25). If results are truncated, use date filters or more specific search terms to narrow. WARNING: Compound filters are unreliable — use one filter per call.',
     inputSchema: {
-      query: z.string().optional().describe('Search query (e.g., "email:domain.com", "subject:billing"). Compound queries mixing a prefix filter with keywords are unreliable — make separate calls for each filter.'),
-      status: z.enum(['active', 'pending', 'closed', 'spam', 'all']).optional().describe('Status filter (defaults to "all")'),
-      maxResults: z.number().optional().default(DEFAULT_MAX_RESULTS).describe('Maximum conversations to return (default 25). Use date filters to narrow large result sets.'),
+      query: z
+        .string()
+        .optional()
+        .describe(
+          'Search query (e.g., "email:domain.com", "subject:billing"). Compound queries mixing a prefix filter with keywords are unreliable — make separate calls for each filter.'
+        ),
+      status: z
+        .enum(['active', 'pending', 'closed', 'spam', 'all'])
+        .optional()
+        .describe('Status filter (defaults to "all")'),
+      maxResults: z
+        .number()
+        .optional()
+        .default(DEFAULT_MAX_RESULTS)
+        .describe(
+          'Maximum conversations to return (default 25). Use date filters to narrow large result sets.'
+        ),
       ...dateFilterSchema,
     },
     outputSchema: searchConversationsOutputSchema,
     annotations: READ_ONLY_REMOTE_ANNOTATIONS,
   },
-  async ({ query, status = 'all', maxResults, createdSince, createdBefore, modifiedSince, modifiedBefore }) => {
+  async ({
+    query,
+    status = 'all',
+    maxResults,
+    createdSince,
+    createdBefore,
+    modifiedSince,
+    modifiedBefore,
+  }) => {
     const normalizedQuery = normalizeSearchQuery(query);
-    const dateQuery = buildDateQuery({ createdSince, createdBefore, modifiedSince, modifiedBefore }, normalizedQuery);
+    const dateQuery = buildDateQuery(
+      { createdSince, createdBefore, modifiedSince, modifiedBefore },
+      normalizedQuery
+    );
     const all = await client.listAllConversations({ query: dateQuery, status }, maxResults);
     return structuredJsonResult(withOmissionMeta(all, maxResults));
-  },
+  }
 );
 
-rememberTool('get_conversations_summary', 'Get aggregated summary of conversations by status and tag. Fetches up to maxResults conversations (default 25) for summarization. Use date filters to scope the window.');
+rememberTool(
+  'get_conversations_summary',
+  'Get aggregated summary of conversations by status and tag. Fetches up to maxResults conversations (default 25) for summarization. Use date filters to scope the window.'
+);
 server.registerTool(
   'get_conversations_summary',
   {
     title: 'Summarize Conversations',
-    description: 'Get aggregated summary of conversations by status and tag. Fetches up to maxResults conversations (default 25) for summarization. Use date filters to scope the window.',
+    description:
+      'Get aggregated summary of conversations by status and tag. Fetches up to maxResults conversations (default 25) for summarization. Use date filters to scope the window.',
     inputSchema: {
-      status: z.enum(['active', 'pending', 'closed', 'spam', 'all']).optional().describe('Status filter'),
+      status: z
+        .enum(['active', 'pending', 'closed', 'spam', 'all'])
+        .optional()
+        .describe('Status filter'),
       mailbox: z.string().optional().describe('Mailbox ID to filter by'),
       tag: z.string().optional().describe('Tag to filter by'),
-      maxResults: z.number().optional().default(DEFAULT_MAX_RESULTS).describe('Maximum conversations to summarize (default 25)'),
+      maxResults: z
+        .number()
+        .optional()
+        .default(DEFAULT_MAX_RESULTS)
+        .describe('Maximum conversations to summarize (default 25)'),
       ...dateFilterSchema,
     },
     outputSchema: conversationSummaryOutputSchema,
     annotations: READ_ONLY_REMOTE_ANNOTATIONS,
   },
-  async ({ status, mailbox, tag, maxResults, createdSince, createdBefore, modifiedSince, modifiedBefore }) => {
-    const dateQuery = buildDateQuery({ createdSince, createdBefore, modifiedSince, modifiedBefore });
-    const conversations = await client.listAllConversations({ status, mailbox, tag, query: dateQuery }, maxResults);
+  async ({
+    status,
+    mailbox,
+    tag,
+    maxResults,
+    createdSince,
+    createdBefore,
+    modifiedSince,
+    modifiedBefore,
+  }) => {
+    const dateQuery = buildDateQuery({
+      createdSince,
+      createdBefore,
+      modifiedSince,
+      modifiedBefore,
+    });
+    const conversations = await client.listAllConversations(
+      { status, mailbox, tag, query: dateQuery },
+      maxResults
+    );
     return structuredJsonResult(summarizeConversations(conversations));
-  },
+  }
 );
 
 rememberTool('list_mailboxes', 'List all mailboxes in the Help Scout account');
@@ -821,7 +1079,7 @@ server.registerTool(
       mailboxes: result.mailboxes.map(cleanMailbox),
       page: result.page,
     });
-  },
+  }
 );
 
 rememberTool('get_mailbox', 'Get detailed information about a specific mailbox');
@@ -836,7 +1094,7 @@ server.registerTool(
     outputSchema: mailboxSchema,
     annotations: READ_ONLY_REMOTE_ANNOTATIONS,
   },
-  async ({ mailboxId }) => structuredJsonResult(cleanMailbox(await client.getMailbox(mailboxId))),
+  async ({ mailboxId }) => structuredJsonResult(cleanMailbox(await client.getMailbox(mailboxId)))
 );
 
 rememberTool('list_customers', 'List customers with optional filtering');
@@ -860,7 +1118,7 @@ server.registerTool(
       customers: result.customers.map(cleanCustomer),
       page: result.page,
     });
-  },
+  }
 );
 
 rememberTool('get_customer', 'Get detailed information about a specific customer');
@@ -882,18 +1140,22 @@ server.registerTool(
       resourceLinkContent(
         customerResourceUri(customerId),
         `Customer ${customerId}`,
-        'Detailed Help Scout customer resource',
+        'Detailed Help Scout customer resource'
       ),
     ]);
-  },
+  }
 );
 
-rememberTool('list_users', 'List Help Scout users and mention handles with optional exact email, mailbox, and page filters');
+rememberTool(
+  'list_users',
+  'List Help Scout users and mention handles with optional exact email, mailbox, and page filters'
+);
 server.registerTool(
   'list_users',
   {
     title: 'List Users',
-    description: 'List Help Scout users and mention handles with optional exact email, mailbox, and page filters',
+    description:
+      'List Help Scout users and mention handles with optional exact email, mailbox, and page filters',
     inputSchema: {
       email: z.string().email().optional().describe('Exact-match email filter'),
       mailbox: z.number().optional().describe('Mailbox ID to filter by'),
@@ -908,15 +1170,19 @@ server.registerTool(
       users: result.users.map(cleanUser),
       page: result.page,
     });
-  },
+  }
 );
 
-rememberTool('get_user', 'Get detailed information about a specific Help Scout user, including the mention handle for @mentions');
+rememberTool(
+  'get_user',
+  'Get detailed information about a specific Help Scout user, including the mention handle for @mentions'
+);
 server.registerTool(
   'get_user',
   {
     title: 'Get User',
-    description: 'Get detailed information about a specific Help Scout user, including the mention handle for @mentions',
+    description:
+      'Get detailed information about a specific Help Scout user, including the mention handle for @mentions',
     inputSchema: {
       userId: z.number().describe('User ID'),
     },
@@ -930,10 +1196,10 @@ server.registerTool(
       resourceLinkContent(
         userResourceUri(userId),
         `User ${userId}`,
-        'Detailed Help Scout user resource',
+        'Detailed Help Scout user resource'
       ),
     ]);
-  },
+  }
 );
 
 rememberTool('list_tags', 'List all tags in the Help Scout account');
@@ -954,7 +1220,7 @@ server.registerTool(
       tags: result.tags.map(cleanTag),
       page: result.page,
     });
-  },
+  }
 );
 
 rememberTool('list_workflows', 'List workflows with optional filtering');
@@ -977,7 +1243,7 @@ server.registerTool(
       workflows: result.workflows.map(cleanWorkflow),
       page: result.page,
     });
-  },
+  }
 );
 
 rememberTool('create_note', 'Add a private note to a conversation');
@@ -992,7 +1258,9 @@ server.registerTool(
       status: z
         .string()
         .optional()
-        .describe('Optionally set the conversation status after adding the note (active, open, pending, closed, spam)'),
+        .describe(
+          'Optionally set the conversation status after adding the note (active, open, pending, closed, spam)'
+        ),
     },
     outputSchema: noteOutputSchema,
     annotations: MUTATING_REMOTE_ANNOTATIONS,
@@ -1006,15 +1274,19 @@ server.registerTool(
       conversationId,
       ...(normalizedStatus && { status: normalizedStatus }),
     });
-  },
+  }
 );
 
-rememberTool('create_draft_reply', 'Create a draft reply on an existing conversation (saves without sending). Use this when responding to an existing ticket — the draft is reviewed and sent from the Help Scout UI. For starting a brand-new outbound conversation, use create_draft_conversation instead.');
+rememberTool(
+  'create_draft_reply',
+  'Create a draft reply on an existing conversation (saves without sending). Use this when responding to an existing ticket — the draft is reviewed and sent from the Help Scout UI. For starting a brand-new outbound conversation, use create_draft_conversation instead.'
+);
 server.registerTool(
   'create_draft_reply',
   {
     title: 'Create Draft Reply',
-    description: 'Create a draft reply on an existing conversation (saves without sending). Use this when responding to an existing ticket — the draft is reviewed and sent from the Help Scout UI. For starting a brand-new outbound conversation, use create_draft_conversation instead.',
+    description:
+      'Create a draft reply on an existing conversation (saves without sending). Use this when responding to an existing ticket — the draft is reviewed and sent from the Help Scout UI. For starting a brand-new outbound conversation, use create_draft_conversation instead.',
     inputSchema: {
       conversationId: conversationRefSchema,
       text: z.string().describe('Draft reply text content (HTML or plain text)'),
@@ -1026,22 +1298,32 @@ server.registerTool(
     const conversationId = await client.resolveConversationId(conversationRef);
     await client.createDraftReply(conversationId, { text });
     return structuredJsonResult({ success: true, conversationId });
-  },
+  }
 );
 
-rememberTool('create_draft_conversation', 'Create a brand-new outbound draft conversation for proactive customer outreach (saves without sending). Use this when starting a new ticket from scratch — the draft is reviewed and sent from the Help Scout UI. For replying to an existing conversation, use create_draft_reply instead.');
+rememberTool(
+  'create_draft_conversation',
+  'Create a brand-new outbound draft conversation for proactive customer outreach (saves without sending). Use this when starting a new ticket from scratch — the draft is reviewed and sent from the Help Scout UI. For replying to an existing conversation, use create_draft_reply instead.'
+);
 server.registerTool(
   'create_draft_conversation',
   {
     title: 'Create Draft Conversation',
-    description: 'Create a brand-new outbound draft conversation for proactive customer outreach (saves without sending). Use this when starting a new ticket from scratch — the draft is reviewed and sent from the Help Scout UI. For replying to an existing conversation, use create_draft_reply instead.',
+    description:
+      'Create a brand-new outbound draft conversation for proactive customer outreach (saves without sending). Use this when starting a new ticket from scratch — the draft is reviewed and sent from the Help Scout UI. For replying to an existing conversation, use create_draft_reply instead.',
     inputSchema: {
       mailboxId: z.number().describe('Mailbox ID to create the conversation in'),
       customerEmail: z.string().email().describe('Recipient customer email address'),
       subject: z.string().describe('Conversation subject line'),
       text: z.string().describe('Draft message body (HTML or plain text)'),
-      type: z.enum(['email', 'chat', 'phone']).optional().describe('Conversation medium (default "email")'),
-      status: z.enum(['active', 'pending', 'closed']).optional().describe('Conversation status (default "active")'),
+      type: z
+        .enum(['email', 'chat', 'phone'])
+        .optional()
+        .describe('Conversation medium (default "email")'),
+      status: z
+        .enum(['active', 'pending', 'closed'])
+        .optional()
+        .describe('Conversation status (default "active")'),
       tags: z.array(z.string()).optional().describe('Tags to apply to the conversation'),
     },
     outputSchema: draftConversationOutputSchema,
@@ -1058,15 +1340,19 @@ server.registerTool(
       tags,
     });
     return structuredJsonResult({ success: true, conversationId: result.id });
-  },
+  }
 );
 
-rememberTool('update_conversation_status', 'Change the status of an existing conversation. Accepts active, open, pending, closed, or spam; open is normalized to active.');
+rememberTool(
+  'update_conversation_status',
+  'Change the status of an existing conversation. Accepts active, open, pending, closed, or spam; open is normalized to active.'
+);
 server.registerTool(
   'update_conversation_status',
   {
     title: 'Update Conversation Status',
-    description: 'Change the status of an existing conversation. Accepts active, open, pending, closed, or spam; open is normalized to active.',
+    description:
+      'Change the status of an existing conversation. Accepts active, open, pending, closed, or spam; open is normalized to active.',
     inputSchema: {
       conversationId: conversationRefSchema,
       status: z
@@ -1081,7 +1367,7 @@ server.registerTool(
     const normalizedStatus = normalizeConversationStatus(status);
     await client.updateConversationStatus(conversationId, normalizedStatus);
     return structuredJsonResult({ success: true, conversationId, status: normalizedStatus });
-  },
+  }
 );
 
 rememberTool('add_tag', 'Add a tag to a conversation');
@@ -1101,25 +1387,44 @@ server.registerTool(
     const conversationId = await client.resolveConversationId(conversationRef);
     await client.addConversationTag(conversationId, tag);
     return structuredJsonResult({ success: true, conversationId, tag });
-  },
+  }
 );
 
-rememberTool('search_by_customer', "Find conversations involving a customer by email. Searches primary email and domain (for CC'd/teammate tickets). Results deduplicated and capped by maxResults (default 25). Use date filters to narrow large result sets.");
+rememberTool(
+  'search_by_customer',
+  "Find conversations involving a customer by email. Searches primary email and domain (for CC'd/teammate tickets). Results deduplicated and capped by maxResults (default 25). Use date filters to narrow large result sets."
+);
 server.registerTool(
   'search_by_customer',
   {
     title: 'Search By Customer',
-    description: "Find conversations involving a customer by email. Searches primary email and domain (for CC'd/teammate tickets). Results deduplicated and capped by maxResults (default 25). Use date filters to narrow large result sets.",
+    description:
+      "Find conversations involving a customer by email. Searches primary email and domain (for CC'd/teammate tickets). Results deduplicated and capped by maxResults (default 25). Use date filters to narrow large result sets.",
     inputSchema: {
       email: z.string().email().describe('Customer email address'),
-      status: z.enum(['active', 'pending', 'closed', 'spam', 'all']).optional().describe('Status filter (defaults to "all")'),
-      maxResults: z.number().optional().default(DEFAULT_MAX_RESULTS).describe('Maximum conversations to return (default 25)'),
+      status: z
+        .enum(['active', 'pending', 'closed', 'spam', 'all'])
+        .optional()
+        .describe('Status filter (defaults to "all")'),
+      maxResults: z
+        .number()
+        .optional()
+        .default(DEFAULT_MAX_RESULTS)
+        .describe('Maximum conversations to return (default 25)'),
       ...dateFilterSchema,
     },
     outputSchema: searchByCustomerOutputSchema,
     annotations: READ_ONLY_REMOTE_ANNOTATIONS,
   },
-  async ({ email, status = 'all', maxResults, createdSince, createdBefore, modifiedSince, modifiedBefore }) => {
+  async ({
+    email,
+    status = 'all',
+    maxResults,
+    createdSince,
+    createdBefore,
+    modifiedSince,
+    modifiedBefore,
+  }) => {
     const domain = email.split('@')[1];
     const dateFilters = { createdSince, createdBefore, modifiedSince, modifiedBefore };
 
@@ -1129,10 +1434,13 @@ server.registerTool(
     const isGenericDomain = GENERIC_EMAIL_DOMAINS.has(domain);
     const domainSearch = isGenericDomain
       ? Promise.resolve([] as Conversation[])
-      : client.listAllConversations({
-          query: buildDateQuery(dateFilters, `@${domain}`),
-          status,
-        }, maxResults);
+      : client.listAllConversations(
+          {
+            query: buildDateQuery(dateFilters, `@${domain}`),
+            status,
+          },
+          maxResults
+        );
 
     const [emailResults, domainResults] = await Promise.all([emailSearch, domainSearch]);
 
@@ -1162,7 +1470,7 @@ server.registerTool(
         totalAfterDedup: all.length,
       },
     });
-  },
+  }
 );
 
 rememberTool('check_auth', 'Check if Help Scout authentication is configured');
@@ -1174,29 +1482,37 @@ server.registerTool(
     outputSchema: authStatusOutputSchema,
     annotations: READ_ONLY_LOCAL_ANNOTATIONS,
   },
-  async () => structuredJsonResult({ authenticated: await auth.isAuthenticated() }),
+  async () => structuredJsonResult({ authenticated: await auth.isAuthenticated() })
 );
 
-rememberTool('search_tools', 'Search for available tools by name or description using regex. Returns matching tool names.');
+rememberTool(
+  'search_tools',
+  'Search for available tools by name or description using regex. Returns matching tool names.'
+);
 server.registerTool(
   'search_tools',
   {
     title: 'Search Tools',
-    description: 'Search for available tools by name or description using regex. Returns matching tool names.',
+    description:
+      'Search for available tools by name or description using regex. Returns matching tool names.',
     inputSchema: {
-      query: z.string().describe('Regex pattern to match against tool names and descriptions (case-insensitive)'),
+      query: z
+        .string()
+        .describe('Regex pattern to match against tool names and descriptions (case-insensitive)'),
     },
     annotations: READ_ONLY_LOCAL_ANNOTATIONS,
   },
   async ({ query }) => {
     try {
       const pattern = new RegExp(query, 'i');
-      const matches = toolRegistry.filter((tool) => pattern.test(tool.name) || pattern.test(tool.description));
+      const matches = toolRegistry.filter(
+        (tool) => pattern.test(tool.name) || pattern.test(tool.description)
+      );
       return textJsonResult({ tools: matches });
     } catch {
       return textJsonResult({ error: 'Invalid regex pattern' }, true);
     }
-  },
+  }
 );
 
 export async function runMcpServer() {


### PR DESCRIPTION
## Summary

Adds the HelpScout MCP primitives needed for Fortress GTD triage to fetch full ticket context and safely mutate no-action conversations. The release makes thread retrieval page through all Help Scout thread pages, adds a dedicated full-history thread tool, documents the existing safe status/note tools, and bumps the package to 2.16.0.

## Problem

The prior MCP surface was insufficient for HelpScout GTD triage because agents could list tickets but could not reliably fetch complete thread history or discover the safe close/private-note mutations from the MCP tool surface.