### PR TITLE
fix(mcp): allow unknown fields on nested thread and page objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/helpscout-cli",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "A command-line interface for Help Scout",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -28,4 +28,24 @@ describe('Help Scout MCP server helpers', () => {
       ])
     );
   });
+
+  // Help Scout system-action threads (assigned/moved/merged) carry
+  // action.associatedEntities. The action sub-object must stay passthrough so
+  // its closed JSON output schema doesn't reject real payloads downstream.
+  it('preserves unknown action fields on threads instead of rejecting them', () => {
+    const thread = {
+      id: 1,
+      type: 'lineitem',
+      createdAt: '2026-01-01T00:00:00Z',
+      action: {
+        type: 'movedFromMailbox',
+        text: 'Moved from Sales',
+        associatedEntities: { mailboxIds: [42] },
+      },
+    };
+
+    const parsed = mcpServer.getThreadSchemaForTesting().parse(thread);
+
+    expect(parsed.action?.associatedEntities).toEqual({ mailboxIds: [42] });
+  });
 });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -227,12 +227,14 @@ function userResourceUri(userId: number) {
   return `helpscout://user/${userId}`;
 }
 
-const pageInfoSchema = z.object({
-  size: z.number(),
-  totalElements: z.number(),
-  totalPages: z.number(),
-  number: z.number(),
-});
+const pageInfoSchema = z
+  .object({
+    size: z.number(),
+    totalElements: z.number(),
+    totalPages: z.number(),
+    number: z.number(),
+  })
+  .passthrough();
 
 const personSchema = z
   .object({
@@ -294,6 +296,7 @@ const conversationSchema = z
         time: z.string(),
         friendly: z.string(),
       })
+      .passthrough()
       .optional(),
     source: sourceSchema.optional(),
     tags: z.array(tagSchema).optional(),
@@ -318,6 +321,7 @@ const threadSchema = z
         type: z.string(),
         text: z.string().optional(),
       })
+      .passthrough()
       .optional(),
     body: z.string().optional(),
     source: sourceSchema.optional(),
@@ -625,6 +629,11 @@ function rememberTool(name: string, description: string) {
 
 export function getRegisteredToolsForTesting() {
   return [...toolRegistry];
+}
+
+/** Exposed for tests guarding the thread output schema against over-strict nesting. */
+export function getThreadSchemaForTesting() {
+  return threadSchema;
 }
 
 const dateFilterSchema = {


### PR DESCRIPTION
## Problem

An agent using the HelpScout MCP server hit a hard failure on `get_conversation` / `get_conversation_threads`: the connector fetched thread data fine, then the response was rejected during structured-output validation. Root cause is in this repo's output schema, not permissions or network.

The thread `action` sub-object was declared as a plain `z.object({ type, text })` — **without `.passthrough()`** — while every other API-mirroring schema in `server.ts` (`threadSchema`, `conversationSchema`, `customerSchema`, …) uses `.passthrough()`. The MCP SDK converts a plain object to JSON schema with `additionalProperties: false`, so the closed `action` schema rejects real Help Scout payloads, which carry `action.associatedEntities` on system-action threads (assigned / moved / merged).

Mechanism nuance: the connector's own server-side validation (`validateToolOutput` → zod `safeParseAsync`) uses zod's default *strip* mode, which silently drops unknown keys and **passes**. The hard failure is on the **client/harness** side, which validates the returned `structuredContent` against the advertised `additionalProperties: false` schema and throws before handing data to the caller.

## Fix

Make the three nested objects that mirror raw API data `.passthrough()`, matching the file's convention:

- `threadSchema.action` — the field that caused the reported failure (`associatedEntities`)
- `conversationSchema.customerWaitingSince` — same latent class
- `pageInfoSchema` — populated straight from `result.page`; closed today, but breaks identically if Help Scout adds a field

Self-constructed output envelopes (list wrappers, `searchByCustomer.meta`, action results) keep their closed schemas — we control those keys.

Adds a regression test asserting unknown `action` fields are preserved rather than dropped (strip vs. passthrough is behaviorally distinguishable).

## Verification

- `bun run typecheck`, `bun run lint`, `bun test` (43 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)