### PR TITLE
Fix draft-reply 400: include required customer field in reply payload

### DIFF
--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -380,8 +380,15 @@ export class HelpScoutClient {
       user?: number;
     }
   ) {
+    const conversation = await this.getConversation(conversationId);
+    const customerId = conversation?.primaryCustomer?.id;
+    if (!customerId) {
+      throw new Error(
+        `Cannot create draft reply: conversation ${conversationId} has no primary customer`
+      );
+    }
     await this.request<void>('POST', `/conversations/${conversationId}/reply`, {
-      body: { ...data, draft: true },
+      body: { ...data, customer: { id: customerId }, draft: true },
     });
   }
 


### PR DESCRIPTION
## Problem

Every `helpscout conversations draft-reply` call fails with an opaque `400 Bad Request`.

`createDraftReply` POSTs `{text, user, draft: true}` to `/v2/conversations/{id}/reply`, but the Help Scout API requires a `customer` field on that endpoint ([API docs](https://developer.helpscout.com/mailbox-api/endpoints/conversations/threads/reply/)), so the request is always rejected. The MCP `create_draft_reply` tool hits the same failure since it shares this client method.

## Fix

Fetch the conversation first and include `customer: { id: primaryCustomer.id }` in the reply payload. If a conversation somehow has no primary customer, throw a clear error instead of letting the API return an unexplained 400. `draft: true` remains hardcoded, so the command still never sends.

Verified against a live Help Scout mailbox: before the change every draft-reply returned 400; with the patched client, drafts are created and appear with `state: draft` for review in the UI.

`bun run typecheck` and `bun run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)