### PR TITLE
feat(drafts): prevent duplicate Help Scout replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,17 @@ helpscout conversations threads 456
 helpscout conversations threads 456 --type customer  # Filter by type
 helpscout conversations threads 456 --html          # HTML output
 helpscout conversations threads 456 --include-notes
+helpscout conversations draft-replies list 456
+helpscout conversations draft-replies create 456 --text "Unsent draft"
+helpscout conversations draft-replies update 456 987654 --text "Revised unsent draft"
+helpscout conversations draft-replies upsert 456 --text "Desired unsent draft"
+helpscout conversations draft-replies upsert 456 --thread-id 987654 --text "Chosen draft"
+helpscout conversations draft-reply 456 --text "Desired unsent draft" # shorthand for upsert
 helpscout conversations attachments download 456 789
 helpscout conversations attachments download 456 789 --output ./invoice.pdf
 helpscout conversations attachments download 456 789 --output ./downloads/
 helpscout conversations attachments download 456 789 --force
 helpscout conversations status 456 closed
-helpscout conversations reply 456 --text "Thanks for reaching out!"
 helpscout conversations note 456 --text "Internal note"
 helpscout conversations add-tag 456 urgent
 helpscout conversations remove-tag 456 urgent
@@ -110,6 +115,10 @@ The MCP server exposes:
 - Typed tools for Help Scout search, full conversation detail, full conversation thread history, attachment downloads, mailbox/customer/user lookup, and safe draft-note/status mutations
 - `get_conversation` accepts internal conversation IDs or visible ticket numbers like `#12345`
 - `get_conversation_threads` returns all Help Scout thread types by default, including notes, workflow events, status events, and other system events returned by Help Scout
+- `list_draft_replies` returns active unsent reply drafts with thread IDs, bodies/previews, recipients, authors, and timestamps
+- `create_draft_reply` intentionally creates an additional unsent draft and returns its verified Help Scout `Resource-ID` thread ID
+- `update_draft_reply` replaces `/text` only after verifying the selected thread is still an unsent reply draft, then verifies the live result
+- `upsert_draft_reply` updates the sole active draft or creates one when none exists; it refuses multiple drafts unless `threadId` explicitly selects one
 - `download_attachment` saves a conversation attachment to disk, using the Help Scout filename by default and requiring `force` before overwriting existing files
 - `update_conversation_status` safely changes ticket status, with `open` normalized to Help Scout's `active` status
 - `create_note` adds private notes and can optionally set the ticket status, such as closing no-action tickets
@@ -118,6 +127,14 @@ The MCP server exposes:
 - Prompt templates for `summarize_ticket` and `draft_reply`
 
 Read-only tools include MCP annotations so hosts can distinguish them from mutating tools, and core read/query tools return structured outputs alongside readable JSON text.
+
+### Draft reply safety
+
+All draft-reply commands and MCP tools preserve the never-send boundary: they only list drafts, create with `draft: true`, or replace a draft thread's `/text`. Every create/update re-reads Help Scout and returns success only when the intended thread is still a draft with the requested text.
+
+`draft-replies upsert` and the legacy `draft-reply` shorthand are the recommended write paths. With zero active drafts they create one; with one they update it in place; with multiple they refuse and print the candidate thread IDs. Pass `--thread-id` (or MCP `threadId`) only after selecting the intended draft from `draft-replies list` / `list_draft_replies`.
+
+Help Scout's official Inbox API does not expose an endpoint to delete or discard a draft reply thread. Discard unwanted drafts in the Help Scout web UI.
 
 ## Options
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/helpscout-cli",
-  "version": "2.17.1",
+  "version": "2.18.0",
   "description": "A command-line interface for Help Scout",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/commands/conversations.test.ts
+++ b/src/commands/conversations.test.ts
@@ -18,4 +18,21 @@ describe('conversations command', () => {
       '-f, --force',
     ]);
   });
+
+  it('registers complete safe draft-reply lifecycle commands', () => {
+    const conversations = createConversationsCommand();
+    const legacyUpsert = conversations.commands.find((command) => command.name() === 'draft-reply');
+    const drafts = conversations.commands.find((command) => command.name() === 'draft-replies');
+
+    expect(legacyUpsert?.options.map((option) => option.flags)).toContain('--thread-id <id>');
+    expect(drafts?.commands.map((command) => command.name())).toEqual([
+      'list',
+      'create',
+      'update',
+      'upsert',
+    ]);
+    expect(
+      drafts?.commands.find((command) => command.name() === 'update')?.registeredArguments
+    ).toHaveLength(2);
+  });
 });

--- a/src/commands/conversations.ts
+++ b/src/commands/conversations.ts
@@ -337,11 +337,12 @@ export function createConversationsCommand(): Command {
   cmd
     .command('draft-reply')
     .description(
-      'Create a draft reply on an existing conversation (never sends — review and send from the Help Scout UI)'
+      'Upsert a draft reply (never sends; refuses ambiguous multiple-draft conversations)'
     )
     .argument('<id>', 'Conversation ID, or ticket number prefixed with "#" (e.g. "#12345")')
     .requiredOption('--text <text>', 'Reply text')
     .option('--user <id>', 'User ID authoring the draft')
+    .option('--thread-id <id>', 'Explicit draft thread ID to update')
     .action(
       withErrorHandling(
         async (
@@ -349,16 +350,89 @@ export function createConversationsCommand(): Command {
           options: {
             text: string;
             user?: string;
+            threadId?: string;
           }
         ) => {
-          await client.createDraftReply(await client.resolveConversationId(id), {
+          const result = await client.upsertDraftReply(await client.resolveConversationId(id), {
             text: options.text,
             user: options.user ? parseIdArg(options.user, 'user') : undefined,
+            threadId: options.threadId ? parseIdArg(options.threadId, 'thread') : undefined,
           });
-          outputJson({ message: 'Draft reply created' });
+          outputJson({ message: `Draft reply ${result.action}`, ...result });
         }
       )
     );
+
+  const draftReplies = new Command('draft-replies').description(
+    'Manage unsent draft replies; these commands never publish or send'
+  );
+
+  draftReplies
+    .command('list')
+    .description('List active draft replies with thread IDs, metadata, and body previews')
+    .argument('<id>', 'Conversation ID, or ticket number prefixed with "#"')
+    .action(
+      withErrorHandling(async (id: string) => {
+        const conversationId = await client.resolveConversationId(id);
+        const drafts = await client.listDraftReplies(conversationId);
+        outputJson({ conversationId, drafts, total: drafts.length });
+      })
+    );
+
+  draftReplies
+    .command('create')
+    .description('Create a new unsent draft reply and verify its Resource-ID thread')
+    .argument('<id>', 'Conversation ID, or ticket number prefixed with "#"')
+    .requiredOption('--text <text>', 'Reply text')
+    .option('--user <id>', 'User ID authoring the draft')
+    .action(
+      withErrorHandling(async (id: string, options: { text: string; user?: string }) => {
+        const result = await client.createDraftReply(await client.resolveConversationId(id), {
+          text: options.text,
+          user: options.user ? parseIdArg(options.user, 'user') : undefined,
+        });
+        outputJson({ message: 'Draft reply created', ...result });
+      })
+    );
+
+  draftReplies
+    .command('update')
+    .description('Update one specific unsent draft reply in place and verify it')
+    .argument('<id>', 'Conversation ID, or ticket number prefixed with "#"')
+    .argument('<threadId>', 'Draft reply thread ID')
+    .requiredOption('--text <text>', 'Replacement reply text')
+    .action(
+      withErrorHandling(async (id: string, threadId: string, options: { text: string }) => {
+        const result = await client.updateDraftReply(
+          await client.resolveConversationId(id),
+          parseIdArg(threadId, 'thread'),
+          options.text
+        );
+        outputJson({ message: 'Draft reply updated', ...result });
+      })
+    );
+
+  draftReplies
+    .command('upsert')
+    .description('Update the sole active draft or create one when none exists')
+    .argument('<id>', 'Conversation ID, or ticket number prefixed with "#"')
+    .requiredOption('--text <text>', 'Reply text')
+    .option('--thread-id <id>', 'Explicit draft thread ID to update')
+    .option('--user <id>', 'User ID authoring a newly created draft')
+    .action(
+      withErrorHandling(
+        async (id: string, options: { text: string; threadId?: string; user?: string }) => {
+          const result = await client.upsertDraftReply(await client.resolveConversationId(id), {
+            text: options.text,
+            threadId: options.threadId ? parseIdArg(options.threadId, 'thread') : undefined,
+            user: options.user ? parseIdArg(options.user, 'user') : undefined,
+          });
+          outputJson({ message: `Draft reply ${result.action}`, ...result });
+        }
+      )
+    );
+
+  cmd.addCommand(draftReplies);
 
   cmd
     .command('draft-conversation')

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -10,7 +10,23 @@ function thread(id: number, type = 'customer') {
   };
 }
 
-function paginatedThreads(threads: ReturnType<typeof thread>[], page: number, totalPages: number) {
+function draftThread(id: number, body = `<p>Draft ${id}</p>`) {
+  return {
+    id,
+    type: 'message',
+    status: 'active',
+    state: 'draft',
+    body,
+    createdAt: `2026-06-0${id}T00:00:00Z`,
+    createdBy: { id: 42, type: 'user', first: 'Ada', last: 'Lovelace' },
+  };
+}
+
+function paginatedThreads(
+  threads: Array<Record<string, unknown>>,
+  page: number,
+  totalPages: number
+) {
   return Response.json({
     _embedded: { threads },
     page: {
@@ -148,12 +164,20 @@ describe('HelpScoutClient', () => {
     );
   });
 
-  it('includes the primary customer when creating a draft reply', async () => {
+  it('creates a draft reply, parses Resource-ID, and verifies the live thread', async () => {
     fetchMock
       .mockResolvedValueOnce(Response.json({ primaryCustomer: { id: 729732479 } }))
-      .mockResolvedValueOnce(new Response(null, { status: 201 }));
+      .mockResolvedValueOnce(
+        new Response(null, { status: 201, headers: { 'Resource-ID': '10420000001' } })
+      )
+      .mockResolvedValueOnce(
+        paginatedThreads([draftThread(10420000001, '<p>Draft reply</p>')], 1, 1)
+      );
 
-    await client.createDraftReply(3401014297, { text: '<p>Draft reply</p>', user: 903917 });
+    const result = await client.createDraftReply(3401014297, {
+      text: '<p>Draft reply</p>',
+      user: 903917,
+    });
 
     expect(fetchMock.mock.calls[0][0]).toBe(
       'https://api.helpscout.net/v2/conversations/3401014297'
@@ -170,6 +194,151 @@ describe('HelpScoutClient', () => {
         }),
       }),
     ]);
+    expect(result).toEqual(
+      expect.objectContaining({
+        conversationId: 3401014297,
+        threadId: 10420000001,
+        action: 'created',
+        verified: true,
+      })
+    );
+  });
+
+  it('fails creation when Help Scout omits the Resource-ID header', async () => {
+    fetchMock
+      .mockResolvedValueOnce(Response.json({ primaryCustomer: { id: 729732479 } }))
+      .mockResolvedValueOnce(new Response(null, { status: 201 }));
+
+    await expect(client.createDraftReply(123, { text: 'Draft' })).rejects.toThrow(
+      'did not return a valid Resource-ID'
+    );
+  });
+
+  it('lists only active draft reply threads with safe selection metadata', async () => {
+    const longBody = 'x'.repeat(350);
+    fetchMock.mockResolvedValueOnce(
+      paginatedThreads(
+        [
+          draftThread(11, longBody),
+          { ...thread(12, 'message'), state: 'published' },
+          thread(13, 'note'),
+        ],
+        1,
+        1
+      )
+    );
+
+    const drafts = await client.listDraftReplies(123);
+
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]).toEqual(
+      expect.objectContaining({
+        conversationId: 123,
+        threadId: 11,
+        state: 'draft',
+        body: longBody,
+        preview: `${'x'.repeat(300)}...`,
+        createdBy: expect.objectContaining({ id: 42 }),
+      })
+    );
+  });
+
+  it('updates a specific draft with JSON Patch and verifies the result', async () => {
+    fetchMock
+      .mockResolvedValueOnce(paginatedThreads([draftThread(11, 'Old')], 1, 1))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(paginatedThreads([draftThread(11, 'New')], 1, 1));
+
+    const result = await client.updateDraftReply(123, 11, 'New');
+
+    expect(fetchMock.mock.calls[1]).toEqual([
+      'https://api.helpscout.net/v2/conversations/123/threads/11',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ op: 'replace', path: '/text', value: 'New' }),
+      }),
+    ]);
+    expect(result).toEqual(
+      expect.objectContaining({ threadId: 11, action: 'updated', verified: true })
+    );
+  });
+
+  it('refuses to update a published or non-draft thread', async () => {
+    fetchMock.mockResolvedValueOnce(
+      paginatedThreads([{ ...thread(11, 'message'), state: 'published' }], 1, 1)
+    );
+
+    await expect(client.updateDraftReply(123, 11, 'New')).rejects.toThrow('expected a draft reply');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses an unknown thread ID before writing', async () => {
+    fetchMock.mockResolvedValueOnce(paginatedThreads([draftThread(11)], 1, 1));
+
+    await expect(client.updateDraftReply(123, 99, 'New')).rejects.toThrow('does not exist');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates on upsert when no active draft exists', async () => {
+    fetchMock
+      .mockResolvedValueOnce(paginatedThreads([], 1, 1))
+      .mockResolvedValueOnce(Response.json({ primaryCustomer: { id: 7 } }))
+      .mockResolvedValueOnce(new Response(null, { status: 201, headers: { 'Resource-ID': '22' } }))
+      .mockResolvedValueOnce(paginatedThreads([draftThread(22, 'Desired')], 1, 1));
+
+    const result = await client.upsertDraftReply(123, { text: 'Desired' });
+
+    expect(result.action).toBe('created');
+    expect(result.threadId).toBe(22);
+  });
+
+  it('updates the sole active draft on upsert', async () => {
+    fetchMock
+      .mockResolvedValueOnce(paginatedThreads([draftThread(11, 'Old')], 1, 1))
+      .mockResolvedValueOnce(paginatedThreads([draftThread(11, 'Old')], 1, 1))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(paginatedThreads([draftThread(11, 'Desired')], 1, 1));
+
+    const result = await client.upsertDraftReply(123, { text: 'Desired' });
+
+    expect(result.action).toBe('updated');
+    expect(result.threadId).toBe(11);
+  });
+
+  it('refuses ambiguous upsert when multiple active drafts exist', async () => {
+    fetchMock.mockResolvedValueOnce(paginatedThreads([draftThread(11), draftThread(12)], 1, 1));
+
+    await expect(client.upsertDraftReply(123, { text: 'Desired' })).rejects.toThrow(
+      'Refusing to choose among 2 active draft replies (11, 12)'
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses an explicit thread ID to disambiguate upsert', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        paginatedThreads([draftThread(11, 'First'), draftThread(12, 'Second')], 1, 1)
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(
+        paginatedThreads([draftThread(11, 'First'), draftThread(12, 'Desired')], 1, 1)
+      );
+
+    const result = await client.upsertDraftReply(123, { text: 'Desired', threadId: 12 });
+
+    expect(result.threadId).toBe(12);
+    expect(result.action).toBe('updated');
+  });
+
+  it('reports post-write verification failures without claiming success', async () => {
+    fetchMock
+      .mockResolvedValueOnce(paginatedThreads([draftThread(11, 'Old')], 1, 1))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(paginatedThreads([draftThread(11, 'Old')], 1, 1));
+
+    await expect(client.updateDraftReply(123, 11, 'Desired')).rejects.toThrow(
+      'post-write verification failed'
+    );
   });
 
   it('sends private notes with optional status', async () => {

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -6,6 +6,8 @@ import type {
   AttachmentDownload,
   Customer,
   DraftConversationStatus,
+  DraftReply,
+  DraftReplyWriteResult,
   Tag,
   User,
   Workflow,
@@ -36,6 +38,38 @@ interface AuthProvider {
   setRefreshToken(token: string): Promise<boolean>;
   getAppId(): Promise<string | null>;
   getAppSecret(): Promise<string | null>;
+}
+
+const DRAFT_PREVIEW_LENGTH = 300;
+
+function isDraftReply(
+  thread: Thread
+): thread is Thread & { type: 'message'; state: 'draft'; body: string } {
+  return thread.type === 'message' && thread.state === 'draft' && typeof thread.body === 'string';
+}
+
+function toDraftReply(
+  conversationId: number,
+  thread: Thread & { type: 'message'; state: 'draft'; body: string }
+): DraftReply {
+  const preview =
+    thread.body.length > DRAFT_PREVIEW_LENGTH
+      ? `${thread.body.slice(0, DRAFT_PREVIEW_LENGTH).trim()}...`
+      : thread.body;
+  return {
+    threadId: thread.id,
+    conversationId,
+    type: thread.type,
+    state: thread.state,
+    status: thread.status,
+    body: thread.body,
+    preview,
+    createdAt: thread.createdAt,
+    createdBy: thread.createdBy,
+    to: thread.to,
+    cc: thread.cc,
+    bcc: thread.bcc,
+  };
 }
 
 export class HelpScoutClient {
@@ -399,7 +433,7 @@ export class HelpScoutClient {
       text: string;
       user?: number;
     }
-  ) {
+  ): Promise<DraftReplyWriteResult> {
     const conversation = await this.getConversation(conversationId);
     const customerId = conversation?.primaryCustomer?.id;
     if (!customerId) {
@@ -407,9 +441,95 @@ export class HelpScoutClient {
         `Cannot create draft reply: conversation ${conversationId} has no primary customer`
       );
     }
-    await this.request<void>('POST', `/conversations/${conversationId}/reply`, {
+    const response = await this.rawRequest('POST', `/conversations/${conversationId}/reply`, {
       body: { ...data, customer: { id: customerId }, draft: true },
     });
+    const resourceId = response.headers.get('Resource-ID');
+    const threadId = resourceId && /^\d+$/.test(resourceId) ? Number(resourceId) : NaN;
+    if (!Number.isSafeInteger(threadId) || threadId <= 0) {
+      throw new HelpScoutCliError(
+        'Draft reply created but Help Scout did not return a valid Resource-ID thread header',
+        502
+      );
+    }
+    return this.verifyDraftReply(conversationId, threadId, data.text, 'created');
+  }
+
+  async listDraftReplies(conversationId: number): Promise<DraftReply[]> {
+    const threads = await this.getConversationThreads(conversationId);
+    return threads.filter(isDraftReply).map((thread) => toDraftReply(conversationId, thread));
+  }
+
+  async updateDraftReply(
+    conversationId: number,
+    threadId: number,
+    text: string
+  ): Promise<DraftReplyWriteResult> {
+    const threads = await this.getConversationThreads(conversationId);
+    const thread = threads.find((candidate) => candidate.id === threadId);
+    if (!thread) {
+      throw new HelpScoutCliError(
+        `Cannot update draft reply: thread ${threadId} does not exist in conversation ${conversationId}`,
+        404
+      );
+    }
+    if (!isDraftReply(thread)) {
+      throw new HelpScoutCliError(
+        `Refusing to update thread ${threadId}: expected a draft reply (type message, state draft), found type ${thread.type}, state ${thread.state ?? 'unknown'}`,
+        409
+      );
+    }
+
+    await this.request<void>('PATCH', `/conversations/${conversationId}/threads/${threadId}`, {
+      body: { op: 'replace', path: '/text', value: text },
+    });
+    return this.verifyDraftReply(conversationId, threadId, text, 'updated');
+  }
+
+  async upsertDraftReply(
+    conversationId: number,
+    data: { text: string; user?: number; threadId?: number }
+  ): Promise<DraftReplyWriteResult> {
+    if (data.threadId !== undefined) {
+      return this.updateDraftReply(conversationId, data.threadId, data.text);
+    }
+
+    const drafts = await this.listDraftReplies(conversationId);
+    if (drafts.length === 0) {
+      return this.createDraftReply(conversationId, { text: data.text, user: data.user });
+    }
+    if (drafts.length === 1) {
+      return this.updateDraftReply(conversationId, drafts[0].threadId, data.text);
+    }
+
+    const ids = drafts.map((draft) => draft.threadId).join(', ');
+    throw new HelpScoutCliError(
+      `Refusing to choose among ${drafts.length} active draft replies (${ids}). Specify the intended thread ID explicitly.`,
+      409
+    );
+  }
+
+  private async verifyDraftReply(
+    conversationId: number,
+    threadId: number,
+    expectedText: string,
+    action: DraftReplyWriteResult['action']
+  ): Promise<DraftReplyWriteResult> {
+    const threads = await this.getConversationThreads(conversationId);
+    const thread = threads.find((candidate) => candidate.id === threadId);
+    if (!thread || !isDraftReply(thread) || thread.body !== expectedText) {
+      throw new HelpScoutCliError(
+        `Draft reply ${action} but post-write verification failed for thread ${threadId}: expected an unsent draft with the requested text`,
+        502
+      );
+    }
+    return {
+      conversationId,
+      threadId,
+      action,
+      verified: true,
+      draft: toDraftReply(conversationId, thread),
+    };
   }
 
   async createDraftConversation(data: {

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -23,6 +23,10 @@ describe('Help Scout MCP server helpers', () => {
       expect.arrayContaining([
         'get_conversation',
         'get_conversation_threads',
+        'list_draft_replies',
+        'create_draft_reply',
+        'update_draft_reply',
+        'upsert_draft_reply',
         'download_attachment',
         'update_conversation_status',
         'create_note',
@@ -48,5 +52,33 @@ describe('Help Scout MCP server helpers', () => {
     const parsed = mcpServer.getThreadSchemaForTesting().parse(thread);
 
     expect(parsed.action?.associatedEntities).toEqual({ mailboxIds: [42] });
+  });
+
+  it('accepts only verified unsent message drafts in lifecycle outputs', () => {
+    const { draftReplyWriteOutputSchema } = mcpServer.getDraftReplySchemasForTesting();
+    const result = {
+      success: true as const,
+      conversationId: 123,
+      threadId: 456,
+      action: 'updated' as const,
+      verified: true as const,
+      draft: {
+        conversationId: 123,
+        threadId: 456,
+        type: 'message' as const,
+        state: 'draft' as const,
+        body: 'Desired text',
+        preview: 'Desired text',
+        createdAt: '2026-08-12T00:00:00Z',
+      },
+    };
+
+    expect(draftReplyWriteOutputSchema.parse(result)).toEqual(result);
+    expect(() =>
+      draftReplyWriteOutputSchema.parse({
+        ...result,
+        draft: { ...result.draft, state: 'published' },
+      })
+    ).toThrow();
   });
 });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -489,6 +489,36 @@ const conversationThreadsOutputSchema = z.object({
   filtered_types: z.array(z.string()).optional(),
 });
 
+const draftReplySchema = z.object({
+  threadId: z.number(),
+  conversationId: z.number(),
+  type: z.literal('message'),
+  state: z.literal('draft'),
+  status: z.string().optional(),
+  body: z.string(),
+  preview: z.string(),
+  createdAt: z.string(),
+  createdBy: personSchema.optional(),
+  to: z.array(z.string()).optional(),
+  cc: z.array(z.string()).optional(),
+  bcc: z.array(z.string()).optional(),
+});
+
+const listDraftRepliesOutputSchema = z.object({
+  conversationId: z.number(),
+  drafts: z.array(draftReplySchema),
+  total: z.number(),
+});
+
+const draftReplyWriteOutputSchema = z.object({
+  success: z.literal(true),
+  conversationId: z.number(),
+  threadId: z.number(),
+  action: z.enum(['created', 'updated']),
+  verified: z.literal(true),
+  draft: draftReplySchema,
+});
+
 const attachmentDownloadOutputSchema = z.object({
   message: z.literal('Attachment downloaded'),
   conversationId: z.number(),
@@ -652,6 +682,11 @@ export function getRegisteredToolsForTesting() {
 /** Exposed for tests guarding the thread output schema against over-strict nesting. */
 export function getThreadSchemaForTesting() {
   return threadSchema;
+}
+
+/** Exposed for tests guarding the MCP draft lifecycle output contract. */
+export function getDraftReplySchemasForTesting() {
+  return { draftReplySchema, listDraftRepliesOutputSchema, draftReplyWriteOutputSchema };
 }
 
 const dateFilterSchema = {
@@ -1343,26 +1378,102 @@ server.registerTool(
 );
 
 rememberTool(
+  'list_draft_replies',
+  'List active unsent draft replies for a conversation, including thread IDs, body previews, and author metadata.'
+);
+server.registerTool(
+  'list_draft_replies',
+  {
+    title: 'List Draft Replies',
+    description:
+      'List active unsent draft replies for a conversation, including thread IDs, body previews, and author metadata. This tool never sends or changes anything.',
+    inputSchema: { conversationId: conversationRefSchema },
+    outputSchema: listDraftRepliesOutputSchema,
+    annotations: READ_ONLY_REMOTE_ANNOTATIONS,
+  },
+  async ({ conversationId: conversationRef }) => {
+    const conversationId = await client.resolveConversationId(conversationRef);
+    const drafts = await client.listDraftReplies(conversationId);
+    return structuredJsonResult({ conversationId, drafts, total: drafts.length });
+  }
+);
+
+rememberTool(
   'create_draft_reply',
-  'Create a draft reply on an existing conversation (saves without sending). Use this when responding to an existing ticket — the draft is reviewed and sent from the Help Scout UI. For starting a brand-new outbound conversation, use create_draft_conversation instead.'
+  'Create an additional draft reply on an existing conversation and verify its returned thread ID (saves without sending). Prefer upsert_draft_reply when duplicate drafts are not intended.'
 );
 server.registerTool(
   'create_draft_reply',
   {
     title: 'Create Draft Reply',
     description:
-      'Create a draft reply on an existing conversation (saves without sending). Use this when responding to an existing ticket — the draft is reviewed and sent from the Help Scout UI. For starting a brand-new outbound conversation, use create_draft_conversation instead.',
+      'Create an additional draft reply on an existing conversation and verify its returned Resource-ID thread (saves without sending). Prefer upsert_draft_reply when duplicate drafts are not intended. This tool cannot publish or send.',
     inputSchema: {
       conversationId: conversationRefSchema,
       text: z.string().describe('Draft reply text content (HTML or plain text)'),
     },
-    outputSchema: conversationActionOutputSchema,
+    outputSchema: draftReplyWriteOutputSchema,
     annotations: MUTATING_REMOTE_ANNOTATIONS,
   },
   async ({ conversationId: conversationRef, text }) => {
     const conversationId = await client.resolveConversationId(conversationRef);
-    await client.createDraftReply(conversationId, { text });
-    return structuredJsonResult({ success: true, conversationId });
+    const result = await client.createDraftReply(conversationId, { text });
+    return structuredJsonResult({ success: true, ...result });
+  }
+);
+
+rememberTool(
+  'update_draft_reply',
+  'Update one explicitly identified unsent draft reply in place and verify the final text. Refuses non-draft threads and never sends.'
+);
+server.registerTool(
+  'update_draft_reply',
+  {
+    title: 'Update Draft Reply',
+    description:
+      'Update one explicitly identified unsent draft reply in place and verify the final text. Refuses missing, published, or non-reply threads. This tool cannot publish or send.',
+    inputSchema: {
+      conversationId: conversationRefSchema,
+      threadId: z.number().int().positive().describe('Existing draft reply thread ID'),
+      text: z.string().describe('Replacement draft text (HTML or plain text)'),
+    },
+    outputSchema: draftReplyWriteOutputSchema,
+    annotations: MUTATING_REMOTE_ANNOTATIONS,
+  },
+  async ({ conversationId: conversationRef, threadId, text }) => {
+    const conversationId = await client.resolveConversationId(conversationRef);
+    const result = await client.updateDraftReply(conversationId, threadId, text);
+    return structuredJsonResult({ success: true, ...result });
+  }
+);
+
+rememberTool(
+  'upsert_draft_reply',
+  'Safely update the sole active draft reply or create one when none exists. Refuses multiple drafts unless threadId explicitly selects one; never sends.'
+);
+server.registerTool(
+  'upsert_draft_reply',
+  {
+    title: 'Upsert Draft Reply',
+    description:
+      'Safely update the sole active draft reply or create one when none exists. Refuses to choose among multiple drafts unless threadId explicitly selects one. Verifies the final text and cannot publish or send.',
+    inputSchema: {
+      conversationId: conversationRefSchema,
+      text: z.string().describe('Desired draft text (HTML or plain text)'),
+      threadId: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Explicit draft thread ID, required only to disambiguate multiple drafts'),
+    },
+    outputSchema: draftReplyWriteOutputSchema,
+    annotations: MUTATING_REMOTE_ANNOTATIONS,
+  },
+  async ({ conversationId: conversationRef, text, threadId }) => {
+    const conversationId = await client.resolveConversationId(conversationRef);
+    const result = await client.upsertDraftReply(conversationId, { text, threadId });
+    return structuredJsonResult({ success: true, ...result });
   }
 );
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,6 +115,29 @@ export interface Thread {
   openedAt?: string;
 }
 
+export interface DraftReply {
+  threadId: number;
+  conversationId: number;
+  type: 'message';
+  state: 'draft';
+  status?: string;
+  body: string;
+  preview: string;
+  createdAt: string;
+  createdBy?: Thread['createdBy'];
+  to?: string[];
+  cc?: string[];
+  bcc?: string[];
+}
+
+export interface DraftReplyWriteResult {
+  conversationId: number;
+  threadId: number;
+  action: 'created' | 'updated';
+  verified: true;
+  draft: DraftReply;
+}
+
 export interface AttachmentDownload {
   data: Uint8Array;
   contentType?: string;


### PR DESCRIPTION
## Summary

Adds complete draft-reply lifecycle support across the CLI and MCP: list, verified create, in-place update, and ambiguity-safe upsert. Preserves the never-send boundary and documents that draft discard remains a Help Scout UI action because the official API has no draft-thread deletion endpoint.

## Problem

Automation could create drafts but could not identify or revise them reliably, leaving stale and duplicate replies on conversations. Writes now return and verify the exact draft thread, while upsert refuses unsafe selection when multiple drafts exist.

---
Generated with [Claude Code](https://claude.com/claude-code)