### PR TITLE
fix(drafts): verify normalized reply bodies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/helpscout-cli",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "A command-line interface for Help Scout",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -222,6 +222,7 @@ describe('HelpScoutClient', () => {
           draftThread(11, longBody),
           { ...thread(12, 'message'), state: 'published' },
           thread(13, 'note'),
+          { ...draftThread(14), status: 'pending' },
         ],
         1,
         1
@@ -263,12 +264,53 @@ describe('HelpScoutClient', () => {
     );
   });
 
+  it('verifies plain-text newlines after Help Scout converts them to br tags', async () => {
+    fetchMock
+      .mockResolvedValueOnce(paginatedThreads([draftThread(11, 'Old')], 1, 1))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(
+        paginatedThreads([draftThread(11, 'First line<br>Second line')], 1, 1)
+      );
+
+    await expect(client.updateDraftReply(123, 11, 'First line\nSecond line')).resolves.toEqual(
+      expect.objectContaining({ verified: true })
+    );
+  });
+
+  it('verifies semantically equivalent HTML input', async () => {
+    fetchMock
+      .mockResolvedValueOnce(paginatedThreads([draftThread(11, 'Old')], 1, 1))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(
+        paginatedThreads([draftThread(11, '<p>Hello <strong>there</strong></p>')], 1, 1)
+      );
+
+    await expect(client.updateDraftReply(123, 11, 'Hello <strong>there</strong>')).resolves.toEqual(
+      expect.objectContaining({ verified: true })
+    );
+  });
+
+  it('normalizes whitespace and newlines during verification', async () => {
+    fetchMock
+      .mockResolvedValueOnce(paginatedThreads([draftThread(11, 'Old')], 1, 1))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(
+        paginatedThreads([draftThread(11, '<p>Hello there</p><p>Next line</p>')], 1, 1)
+      );
+
+    await expect(
+      client.updateDraftReply(123, 11, '  Hello   there\r\n\nNext line  ')
+    ).resolves.toEqual(expect.objectContaining({ verified: true }));
+  });
+
   it('refuses to update a published or non-draft thread', async () => {
     fetchMock.mockResolvedValueOnce(
       paginatedThreads([{ ...thread(11, 'message'), state: 'published' }], 1, 1)
     );
 
-    await expect(client.updateDraftReply(123, 11, 'New')).rejects.toThrow('expected a draft reply');
+    await expect(client.updateDraftReply(123, 11, 'New')).rejects.toThrow(
+      'expected an active draft reply'
+    );
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -335,6 +377,23 @@ describe('HelpScoutClient', () => {
       .mockResolvedValueOnce(paginatedThreads([draftThread(11, 'Old')], 1, 1))
       .mockResolvedValueOnce(new Response(null, { status: 204 }))
       .mockResolvedValueOnce(paginatedThreads([draftThread(11, 'Old')], 1, 1));
+
+    await expect(client.updateDraftReply(123, 11, 'Desired')).rejects.toThrow(
+      'post-write verification failed'
+    );
+  });
+
+  it.each([
+    ['published state', { state: 'published' }],
+    ['inactive status', { status: 'pending' }],
+    ['non-message type', { type: 'note' }],
+  ])('rejects post-write verification for %s', async (_label, override) => {
+    fetchMock
+      .mockResolvedValueOnce(paginatedThreads([draftThread(11, 'Old')], 1, 1))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(
+        paginatedThreads([{ ...draftThread(11, 'Desired'), ...override }], 1, 1)
+      );
 
     await expect(client.updateDraftReply(123, 11, 'Desired')).rejects.toThrow(
       'post-write verification failed'

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,5 +1,6 @@
 import { auth } from './auth.js';
 import { HelpScoutCliError, HelpScoutApiError } from './errors.js';
+import { normalizeBodyText } from './output.js';
 import type {
   Conversation,
   ConversationStatus,
@@ -44,13 +45,18 @@ const DRAFT_PREVIEW_LENGTH = 300;
 
 function isDraftReply(
   thread: Thread
-): thread is Thread & { type: 'message'; state: 'draft'; body: string } {
-  return thread.type === 'message' && thread.state === 'draft' && typeof thread.body === 'string';
+): thread is Thread & { type: 'message'; state: 'draft'; status: 'active'; body: string } {
+  return (
+    thread.type === 'message' &&
+    thread.state === 'draft' &&
+    thread.status === 'active' &&
+    typeof thread.body === 'string'
+  );
 }
 
 function toDraftReply(
   conversationId: number,
-  thread: Thread & { type: 'message'; state: 'draft'; body: string }
+  thread: Thread & { type: 'message'; state: 'draft'; status: 'active'; body: string }
 ): DraftReply {
   const preview =
     thread.body.length > DRAFT_PREVIEW_LENGTH
@@ -475,7 +481,7 @@ export class HelpScoutClient {
     }
     if (!isDraftReply(thread)) {
       throw new HelpScoutCliError(
-        `Refusing to update thread ${threadId}: expected a draft reply (type message, state draft), found type ${thread.type}, state ${thread.state ?? 'unknown'}`,
+        `Refusing to update thread ${threadId}: expected an active draft reply (type message, state draft, status active), found type ${thread.type}, state ${thread.state ?? 'unknown'}, status ${thread.status ?? 'unknown'}`,
         409
       );
     }
@@ -517,7 +523,11 @@ export class HelpScoutClient {
   ): Promise<DraftReplyWriteResult> {
     const threads = await this.getConversationThreads(conversationId);
     const thread = threads.find((candidate) => candidate.id === threadId);
-    if (!thread || !isDraftReply(thread) || thread.body !== expectedText) {
+    if (
+      !thread ||
+      !isDraftReply(thread) ||
+      normalizeBodyText(thread.body) !== normalizeBodyText(expectedText)
+    ) {
       throw new HelpScoutCliError(
         `Draft reply ${action} but post-write verification failed for thread ${threadId}: expected an unsent draft with the requested text`,
         502

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -27,6 +27,11 @@ export function htmlToPlainText(html: string): string {
     .trim();
 }
 
+/** Compare message bodies after Help Scout's HTML and whitespace normalization. */
+export function normalizeBodyText(body: string): string {
+  return htmlToPlainText(body).replace(/\s+/g, ' ').trim();
+}
+
 function convertBodiesToPlainText(data: unknown): unknown {
   if (Array.isArray(data)) {
     return data.map(convertBodiesToPlainText);

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -67,6 +67,7 @@ describe('Help Scout MCP server helpers', () => {
         threadId: 456,
         type: 'message' as const,
         state: 'draft' as const,
+        status: 'active' as const,
         body: 'Desired text',
         preview: 'Desired text',
         createdAt: '2026-08-12T00:00:00Z',
@@ -78,6 +79,12 @@ describe('Help Scout MCP server helpers', () => {
       draftReplyWriteOutputSchema.parse({
         ...result,
         draft: { ...result.draft, state: 'published' },
+      })
+    ).toThrow();
+    expect(() =>
+      draftReplyWriteOutputSchema.parse({
+        ...result,
+        draft: { ...result.draft, status: 'pending' },
       })
     ).toThrow();
   });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -494,7 +494,7 @@ const draftReplySchema = z.object({
   conversationId: z.number(),
   type: z.literal('message'),
   state: z.literal('draft'),
-  status: z.string().optional(),
+  status: z.literal('active'),
   body: z.string(),
   preview: z.string(),
   createdAt: z.string(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -120,7 +120,7 @@ export interface DraftReply {
   conversationId: number;
   type: 'message';
   state: 'draft';
-  status?: string;
+  status: 'active';
   body: string;
   preview: string;
   createdAt: string;


### PR DESCRIPTION
## Summary

Verify persisted Help Scout drafts by semantic body content so server-side HTML and newline normalization does not turn successful writes into CLI failures. Tighten verified draft output to active unsent message threads and bump the patch release to 2.18.1.

## Problem

Help Scout converts submitted plain-text newlines to HTML `<br>` tags, while v2.18.0 compared the returned body byte-for-byte and incorrectly reported successful draft updates as verification failures.