### PR TITLE
fix(conversations): honor assignee filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/helpscout-cli",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "A command-line interface for Help Scout",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/commands/conversations.test.ts
+++ b/src/commands/conversations.test.ts
@@ -1,7 +1,55 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { client } from '../lib/api-client.js';
 import { createConversationsCommand } from './conversations.js';
 
 describe('conversations command', () => {
+  it('documents assignee filtering for both users and teams', () => {
+    const conversations = createConversationsCommand();
+    const list = conversations.commands.find((command) => command.name() === 'list');
+    const assignedTo = list?.options.find((option) => option.long === '--assigned-to');
+
+    expect(assignedTo?.description).toBe('Filter by assignee user or team ID');
+  });
+
+  it('forwards the assignee ID with combined list filters', async () => {
+    const listConversations = vi.spyOn(client, 'listConversations').mockResolvedValue({
+      conversations: [],
+      page: { number: 1, size: 0, totalElements: 0, totalPages: 0 },
+    });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await createConversationsCommand().parseAsync([
+        'node',
+        'test',
+        'list',
+        '--status',
+        'all',
+        '--assigned-to',
+        '987654',
+        '--sort-field',
+        'modifiedAt',
+        '--sort-order',
+        'asc',
+        '--query',
+        'assigned:"Questionnaires"',
+      ]);
+
+      expect(listConversations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'all',
+          assignedTo: '987654',
+          sortField: 'modifiedAt',
+          sortOrder: 'asc',
+          query: 'assigned:"Questionnaires"',
+        })
+      );
+    } finally {
+      output.mockRestore();
+      listConversations.mockRestore();
+    }
+  });
+
   it('registers the attachment download command and output options', () => {
     const conversations = createConversationsCommand();
     const attachments = conversations.commands.find((command) => command.name() === 'attachments');

--- a/src/commands/conversations.ts
+++ b/src/commands/conversations.ts
@@ -128,7 +128,7 @@ export function createConversationsCommand(): Command {
     .option('-m, --mailbox <id>', 'Filter by mailbox ID')
     .option('-s, --status <status>', 'Filter by status (active, all, closed, open, pending, spam)')
     .option('-t, --tag <tags>', 'Filter by tag(s), comma-separated')
-    .option('--assigned-to <id>', 'Filter by assignee user ID')
+    .option('--assigned-to <id>', 'Filter by assignee user or team ID')
     .option('--created-since <date>', 'Show conversations created after this date')
     .option('--created-before <date>', 'Show conversations created before this date')
     .option('--modified-since <date>', 'Show conversations modified after this date')

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -38,6 +38,22 @@ function paginatedThreads(
   });
 }
 
+function paginatedConversations(
+  conversations: Array<Record<string, unknown>>,
+  page: number,
+  totalPages: number
+) {
+  return Response.json({
+    _embedded: { conversations },
+    page: {
+      size: conversations.length,
+      totalElements: totalPages,
+      totalPages,
+      number: page,
+    },
+  });
+}
+
 describe('HelpScoutClient', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let client: HelpScoutClient;
@@ -162,6 +178,62 @@ describe('HelpScoutClient', () => {
         body: JSON.stringify({ op: 'replace', path: '/status', value: 'closed' }),
       })
     );
+  });
+
+  it('serializes the idiomatic assignee option to the Help Scout wire name', async () => {
+    fetchMock.mockResolvedValueOnce(paginatedConversations([], 1, 1));
+
+    await client.listConversations({ assignedTo: '728656' });
+
+    const url = new URL(fetchMock.mock.calls[0][0]);
+    expect(url.searchParams.get('assigned_to')).toBe('728656');
+    expect(url.searchParams.has('assignedTo')).toBe(false);
+  });
+
+  it('preserves status, sort, query, and page while mapping a team assignee ID', async () => {
+    fetchMock.mockResolvedValueOnce(paginatedConversations([], 3, 3));
+
+    await client.listConversations({
+      status: 'all',
+      assignedTo: '987654',
+      sortField: 'modifiedAt',
+      sortOrder: 'asc',
+      query: 'assigned:"Questionnaires"',
+      page: 3,
+    });
+
+    const url = new URL(fetchMock.mock.calls[0][0]);
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      status: 'all',
+      assigned_to: '987654',
+      sortField: 'modifiedAt',
+      sortOrder: 'asc',
+      query: 'assigned:"Questionnaires"',
+      page: '3',
+    });
+  });
+
+  it('keeps the mapped assignee filter on every conversation page', async () => {
+    fetchMock
+      .mockResolvedValueOnce(paginatedConversations([{ id: 1 }], 1, 2))
+      .mockResolvedValueOnce(paginatedConversations([{ id: 2 }], 2, 2));
+
+    const conversations = await client.listAllConversations({
+      status: 'active',
+      assignedTo: '728656',
+      query: 'assigned:"Questionnaires"',
+    });
+
+    expect(conversations).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const [index, call] of fetchMock.mock.calls.entries()) {
+      const url = new URL(call[0]);
+      expect(url.searchParams.get('assigned_to')).toBe('728656');
+      expect(url.searchParams.has('assignedTo')).toBe(false);
+      expect(url.searchParams.get('page')).toBe(String(index + 1));
+      expect(url.searchParams.get('status')).toBe('active');
+      expect(url.searchParams.get('query')).toBe('assigned:"Questionnaires"');
+    }
   });
 
   it('creates a draft reply, parses Resource-ID, and verifies the live thread', async () => {

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -272,10 +272,11 @@ export class HelpScoutClient {
       query?: string;
     } = {}
   ) {
+    const { assignedTo, ...wireParams } = params;
     const response = await this.request<PaginatedResponse<{ conversations: Conversation[] }>>(
       'GET',
       '/conversations',
-      { params }
+      { params: { ...wireParams, assigned_to: assignedTo } }
     );
     return {
       conversations: response._embedded?.conversations || [],

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -892,7 +892,7 @@ server.registerTool(
         .describe('Conversation status filter (defaults to "all" to include resolved tickets)'),
       mailbox: z.string().optional().describe('Mailbox ID to filter by'),
       tag: z.string().optional().describe('Tag to filter by'),
-      assignedTo: z.string().optional().describe('User ID assigned to'),
+      assignedTo: z.string().optional().describe('User or team ID assigned to'),
       query: z
         .string()
         .optional()


### PR DESCRIPTION
## Summary

Serialize the idiomatic CLI/MCP `assignedTo` option as Help Scout's required `assigned_to` query parameter. Keep the filter intact across pagination and clarify that assignee IDs may identify either users or teams.

## Problem

Help Scout silently ignored the camelCase parameter, so assignee-filtered queue enumeration returned unrelated conversations and could miss older tickets during local verification.

---
Generated with [Claude Code](https://claude.com/claude-code)