### PR TITLE
refactor(api): make query wire contracts explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/helpscout-cli",
-  "version": "2.18.2",
+  "version": "2.18.3",
   "description": "A command-line interface for Help Scout",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -54,6 +54,13 @@ function paginatedConversations(
   });
 }
 
+function paginatedResource(resource: string) {
+  return Response.json({
+    _embedded: { [resource]: [] },
+    page: { size: 0, totalElements: 0, totalPages: 0, number: 1 },
+  });
+}
+
 describe('HelpScoutClient', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let client: HelpScoutClient;
@@ -234,6 +241,69 @@ describe('HelpScoutClient', () => {
       expect(url.searchParams.get('status')).toBe('active');
       expect(url.searchParams.get('query')).toBe('assigned:"Questionnaires"');
     }
+  });
+
+  it.each([
+    {
+      name: 'customers',
+      resource: 'customers',
+      path: '/customers',
+      invoke: () =>
+        client.listCustomers({
+          mailbox: '42',
+          firstName: 'Ada',
+          lastName: 'Lovelace',
+          sortField: 'modifiedAt',
+          sortOrder: 'asc',
+          page: 3,
+          query: 'email:ada@example.com',
+        }),
+      expected: {
+        mailbox: '42',
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        sortField: 'modifiedAt',
+        sortOrder: 'asc',
+        page: '3',
+        query: 'email:ada@example.com',
+      },
+    },
+    {
+      name: 'users',
+      resource: 'users',
+      path: '/users',
+      invoke: () => client.listUsers({ email: 'ada@example.com', mailbox: 42, page: 2 }),
+      expected: { email: 'ada@example.com', mailbox: '42', page: '2' },
+    },
+    {
+      name: 'tags',
+      resource: 'tags',
+      path: '/tags',
+      invoke: () => client.listTags(4),
+      expected: { page: '4' },
+    },
+    {
+      name: 'workflows',
+      resource: 'workflows',
+      path: '/workflows',
+      invoke: () => client.listWorkflows({ mailbox: 42, type: 'manual', page: 5 }),
+      expected: { mailboxId: '42', type: 'manual', page: '5' },
+    },
+    {
+      name: 'mailboxes',
+      resource: 'mailboxes',
+      path: '/mailboxes',
+      invoke: () => client.listMailboxes(6),
+      expected: { page: '6' },
+    },
+  ])('serializes the $name list endpoint with its exact wire contract', async (testCase) => {
+    fetchMock.mockResolvedValueOnce(paginatedResource(testCase.resource));
+
+    await testCase.invoke();
+
+    const url = new URL(fetchMock.mock.calls[0][0]);
+    expect(url.pathname).toBe(`/v2${testCase.path}`);
+    expect(Object.fromEntries(url.searchParams)).toEqual(testCase.expected);
   });
 
   it('creates a draft reply, parses Resource-ID, and verifies the live thread', async () => {

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -272,11 +272,22 @@ export class HelpScoutClient {
       query?: string;
     } = {}
   ) {
-    const { assignedTo, ...wireParams } = params;
     const response = await this.request<PaginatedResponse<{ conversations: Conversation[] }>>(
       'GET',
       '/conversations',
-      { params: { ...wireParams, assigned_to: assignedTo } }
+      {
+        params: {
+          mailbox: params.mailbox,
+          status: params.status,
+          tag: params.tag,
+          assigned_to: params.assignedTo,
+          sortField: params.sortField,
+          sortOrder: params.sortOrder,
+          page: params.page,
+          embed: params.embed,
+          query: params.query,
+        },
+      }
     );
     return {
       conversations: response._embedded?.conversations || [],
@@ -620,7 +631,17 @@ export class HelpScoutClient {
     const response = await this.request<PaginatedResponse<{ customers: Customer[] }>>(
       'GET',
       '/customers',
-      { params }
+      {
+        params: {
+          mailbox: params.mailbox,
+          firstName: params.firstName,
+          lastName: params.lastName,
+          sortField: params.sortField,
+          sortOrder: params.sortOrder,
+          page: params.page,
+          query: params.query,
+        },
+      }
     );
     return {
       customers: response._embedded?.customers || [],
@@ -662,7 +683,7 @@ export class HelpScoutClient {
   // Users
   async listUsers(params: { email?: string; mailbox?: number; page?: number } = {}) {
     const response = await this.request<PaginatedResponse<{ users: User[] }>>('GET', '/users', {
-      params,
+      params: { email: params.email, mailbox: params.mailbox, page: params.page },
     });
     return {
       users: response._embedded?.users || [],
@@ -677,7 +698,7 @@ export class HelpScoutClient {
   // Tags
   async listTags(page?: number) {
     const response = await this.request<PaginatedResponse<{ tags: Tag[] }>>('GET', '/tags', {
-      params: page ? { page } : undefined,
+      params: { page },
     });
     return {
       tags: response._embedded?.tags || [],
@@ -719,7 +740,7 @@ export class HelpScoutClient {
     const response = await this.request<PaginatedResponse<{ mailboxes: Mailbox[] }>>(
       'GET',
       '/mailboxes',
-      { params: page ? { page } : undefined }
+      { params: { page } }
     );
     return {
       mailboxes: response._embedded?.mailboxes || [],


### PR DESCRIPTION
## Summary

Define each Help Scout list endpoint's wire parameters explicitly and add URL-level contract coverage for every list operation. This prevents public CLI/MCP option names from leaking into requests when Help Scout uses inconsistent naming conventions.

## Problem

Help Scout silently ignores unknown query parameters, so implicit object pass-through can turn future naming differences into incomplete or polluted queue results without producing an API error.

---
Generated with [Claude Code](https://claude.com/claude-code)